### PR TITLE
Adding demo scripts

### DIFF
--- a/secrets/transit/vault-transit-rewrap-example/README.md
+++ b/secrets/transit/vault-transit-rewrap-example/README.md
@@ -1,3 +1,47 @@
 # Vault Transit Rewrap Record After Key Rotation Example
 
 These assets are provided to perform the tasks described in the [Transit Secret Re-wrapping](https://www.vaultproject.io/guides/encryption/transit-rewrap.html) guide.
+
+---
+
+## Demo Script Guide
+
+The following files are provided as demo scripts:
+
+- `demo_setup.sh` performs [Step 1 through 3](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#steps) in the guide
+  * Pull and run mysql server 5.7 docker container
+  * Enable transit secret engine
+  * Create `my_app_key` encryption key
+  * Create `rewrap_example` policy
+  * Generate a token to be used by the app
+- `run-app.sh` performs [Step 4](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#step4) in the guide
+  * Runs the example app
+  * Prints out the commends to explore the MySQL DB
+- `rewrap_example.sh` performs [Step 5](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#step-5-rotate-the-encryption-keys) in the guide
+  * Read the `my_app_key` details BEFORE the key rotation
+  * Rotate the `my_app_key` encryption key
+  * Read the `my_app_key` details AFTER the key rotation
+  * Prints out the command to set the `min_decryption_version`
+- `cleanup.sh` re-set your environment
+
+
+### Demo Workflow
+
+> **NOTE:** DON'T FORGET that this demo requires [.NET Core and Docker](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#prerequisites) to run the sample app.
+
+1. Run `demo_setup.sh`
+
+2. Run `run_app.sh`
+  - Open another terminal
+  - Copy and paste the suggested commands to explorer the `user_data` table in mysql
+
+3. Run `rewrap_example.sh` a couple of times and review the key version
+
+4. Run `run_app.sh` again
+  - See the data in the `user_data` table are now rewrapped with the _latest_ encryption key version
+
+To demonstrate the minimum key version restriction feature, repeat #3 and then run the commands suggested in the output (`vault write transit/keys/my_app_key/config min_decryption_version=3`). And then, repeat #4.
+
+Finally, run `cleanup.sh` to re-set your environment so that you can repeat the demo as necessary.
+
+> **WARNING:** The `cleanup.sh` disables the transit secret engine. All encryption keys will be deleted. If you are working against a shared Vault server, you might want to ***manually*** clean up the environment instead.

--- a/secrets/transit/vault-transit-rewrap-example/cleanup.sh
+++ b/secrets/transit/vault-transit-rewrap-example/cleanup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Disable transit secret engine
+vault secrets disable transit
+
+# Delete the app-token.txt file
+rm app-token.txt
+
+# Delete the generated /bin directory
+rm -r bin
+
+# Delete the generated /obj directory
+rm -r obj
+
+echo ""
+echo "#---------------------------------------"
+echo "# To clear data in the user_data table"
+echo "#---------------------------------------"
+echo "  docker exec -it mysql-rewrap mysql -uroot -proot"
+echo "    mysql> USE my_app"
+echo "    mysql> DELETE FROM user_data;"
+echo ""

--- a/secrets/transit/vault-transit-rewrap-example/demo_setup.sh
+++ b/secrets/transit/vault-transit-rewrap-example/demo_setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# INITIAL SETUP: RUN ONLY ONCE
+
+# --------
+# Step 1
+# --------
+# Pull the latest mysql container image
+docker pull mysql/mysql-server:5.7
+
+# Create a directory for our data (change the following line if running on Windows)
+mkdir ~/rewrap-data
+
+# Run the container.  The following command creates a database named 'my_app',
+# specifies the root user password as 'root', and adds a user named vault
+docker run --name mysql-rewrap -p 3306:3306 -v ~/rewrap-data/var/lib/mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_ROOT_HOST=% -e MYSQL_DATABASE=my_app -e MYSQL_USER=vault -e MYSQL_PASSWORD=vaultpw -d mysql/mysql-server:5.7
+
+# --------
+# Step 2
+# --------
+# VAULT_SKIP_VERIFY=true
+
+echo "Enabling transit secret engine"
+vault secrets enable transit
+
+echo "Creating an encryption key, my_app_key"
+vault write -f transit/keys/my_app_key
+
+# --------
+# Step 3
+# --------
+echo "Create rewrap example policy"
+vault policy write rewrap_example ./rewrap_example.hcl
+
+echo "Create a token for the sample app to use and save it in app-token.txt"
+vault token create -policy=rewrap_example -format=json | jq -r ".auth.client_token" > app-token.txt

--- a/secrets/transit/vault-transit-rewrap-example/rewrap_demo.sh
+++ b/secrets/transit/vault-transit-rewrap-example/rewrap_demo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#---------------
+# Step 5
+#---------------
+echo "---------------------------"
+echo " CURRENT key information "
+echo "---------------------------"
+vault read transit/keys/my_app_key
+echo ""
+
+echo "-----------------------------"
+echo " Rotate the encryption key "
+echo "-----------------------------"
+vault write -f transit/keys/my_app_key/rotate
+echo ""
+
+echo "--------------------------------------------"
+echo " Key information AFTER the key rotation "
+echo "--------------------------------------------"
+vault read transit/keys/my_app_key
+echo ""
+
+echo "=========================================================================="
+echo " To set the min_decryption_version, run: "
+echo "  vault write transit/keys/my_app_key/config min_decryption_version=3 "
+echo "     & "
+echo "  vault read transit/keys/my_app_key "
+echo "=========================================================================="
+echo ""

--- a/secrets/transit/vault-transit-rewrap-example/rewrap_example.hcl
+++ b/secrets/transit/vault-transit-rewrap-example/rewrap_example.hcl
@@ -1,0 +1,13 @@
+path "transit/keys/my_app_key" {
+  capabilities = ["read"]
+}
+
+path "transit/rewrap/my_app_key" {
+  capabilities = ["update"]
+}
+
+# This last policy is needed to seed the database as part of the example.
+# It can be omitted if seeding is not required
+path "transit/encrypt/my_app_key" {
+  capabilities = ["update"]
+} 

--- a/secrets/transit/vault-transit-rewrap-example/run-app.sh
+++ b/secrets/transit/vault-transit-rewrap-example/run-app.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+VAULT_TOKEN=$(cat app-token.txt) VAULT_ADDR=$VAULT_ADDR VAULT_TRANSIT_KEY=my_app_key SHOULD_SEED_USERS=true dotnet run
+
+echo ""
+echo "#------------------------------------"
+echo "# To view the data in the MySQL DB"
+echo "#------------------------------------"
+echo "  docker exec -it mysql-rewrap mysql -uroot -proot"
+echo "    mysql> USE my_app"
+echo "    mysql> DESC user_data;"
+echo "    mysql> SELECT * FROM user_data WHERE dob LIKE \"vault:v1%\" limit 10;"
+echo ""


### PR DESCRIPTION
Scripts to demo the transit rewrap example app.

* `demo-setup.sh` 
          - spins up the MySQL docker container
          - enable transit secret engine
          - create a policy
          - generate a token for the app to use
* `run-app.sh` 
          - runs the sample app which generates the `user_data` table in MySQL
* `rewrap_demo.sh` 
          - rotate the encryption key 
          - display the key details
* `cleanup.sh` 
          - disables transit secret engine
          - delete generated files 

So, the flow would be:
1. `demo-setup.sh`
2. `run-app.sh`
3. `rewrap_demo.sh` multiple time if you wish
4. `run-app.sh` again to rewrap existing data in DB

Optional: `cleanup.sh` to re-set your env after the demo