### PR TITLE
Pointing to the vaultproject.io site now

### DIFF
--- a/secrets/spring-cloud-vault/README.md
+++ b/secrets/spring-cloud-vault/README.md
@@ -1,28 +1,39 @@
-# spring-vault-demo
+# Java Sample App using Spring Cloud Vault
 
-Java example for [dynamic secrets](https://www.vaultproject.io/intro/getting-started/dynamic-secrets.html) and [transit encryption](https://www.vaultproject.io/docs/secrets/transit/) using [Spring Cloud Vault](https://cloud.spring.io/spring-cloud-vault)
+These assets are provided to perform the tasks described in the [Java Sample App using Spring Cloud Vault](https://www.vaultproject.io/guides/encryption/spring-demo.html) guide.
 
-Check out our HashiCorp Webinar: https://www.hashicorp.com/resources/solutions-engineering-webinar-series-episode-2-vault
 
-## Overview
+Originally, this app was demonstrated during the [Manage secrets, access, and encryption in the public cloud
+with Vault](https://www.hashicorp.com/resources/solutions-engineering-webinar-series-episode-2-vault)
+webinar.
+
+
+----
+
+
+## Demo Instruction
+
+To keep it simple and lightweight, the [Java Sample App using Spring Cloud Vault](https://www.vaultproject.io/guides/encryption/spring-demo.html) guide used **Vagrant** to demonstrate the app.  This repository also provides example deployments on various platforms:
+
+- [Nomad](nomad)
+- [Kubernetes](kubernetes)
+- [Pivotal Cloud Foundry - PCF](pcf)
+- [Vagrant](vagrant-local)
+<br>
+
+### Setup
 
 You can run the sample as a standalone Java application. You will need a Vault instance and a Postgres instance to get started.
 
 1. Run the [Postgres script](scripts/postgres.sql) at your Postgres instance.
 2. Run the [Vault script](scripts/vault.sh) at your Vault instance.
-3. Update the [bootstrap.yaml](bootstrap.yaml) file for your enviornment.
+3. Update the [bootstrap.yaml](bootstrap.yaml) file for your environment.
 4. Run the Java application.
 5. Try the API.
 
-## Deployment Platforms
-The following provides example deployments on various platforms.
-- [Vagrant](vagrant-local)
-- [Nomad](nomad)
-- [Kubernetes](kubernetes)
-- [Pivotal Cloud Foundry - PCF](pcf)
 
 
-## API USE
+### API
 
 - Get Orders
 ```
@@ -56,7 +67,8 @@ $ curl -s -X DELETE -w "%{http_code}" http://localhost:8080/api/orders | jq
 200
 ```
 
-## Refreshing Static Secrets
+### Refreshing Static Secrets
+
 Spring has an actuator we can use to facilitate the rotation of static credentials. Example below.
 1. Export your env vars
 ```

--- a/secrets/spring-cloud-vault/vagrant-local/README.md
+++ b/secrets/spring-cloud-vault/vagrant-local/README.md
@@ -1,7 +1,69 @@
-# spring-vault-demo-vagrant
+# Java Sample App using Spring Cloud Vault (Vagrant)
 
-The Spring server takes about 20 seconds to start.
-After running `vagrant up` you can check the Spring logs on the demo box with the below command.
+Refer to the [Java Sample App using Spring Cloud Vault](https://www.vaultproject.io/guides/encryption/spring-demo.html) guide for step-by-step instruction.
+
+----
+
+
+## Command List
+
+### Setup
+
+```shell
+# Create and configure a Linux machine. This takes about 3 minutes
+$ vagrant up
+
+# Connect to the demo machine
+$ vagrant ssh demo
+
+# On the demo machine, you should see 3 containers running
+[vagrant@demo ~]$ docker ps
+CONTAINER ID     IMAGE            COMMAND                  CREATED           STATUS           NAMES
+684d8fb23ae5     spring           "java -Djava.secur..."   7 minutes ago     Up 7 minutes     spring
+dc6a3454b323     vault:0.10.0     "docker-entrypoint..."   7 minutes ago     Up 7 minutes     vault
+4093a45c209f     postgres         "docker-entrypoint..."   7 minutes ago     Up 7 minutes     postgres
+
+# Check to verify that Vault is running
+[vagrant@demo ~]$ docker logs vault
+
+# The Spring server takes about 20 seconds to start. Check the Spring logs
+[vagrant@demo ~]$ docker logs spring -f
 ```
-docker logs spring -f
+
+### Test the App
+
+Invoke the `orders` API at http://localhost:8080/api/orders
+
+```shell
+# Create a new order data
+$ tee payload.json<<EOF
+{
+  "customerName": "John",
+  "productName": "Nomad"
+}
+EOF
+
+# Send an order request using cURL
+$ curl --request POST --header "Content-Type: application/json" \
+       --data @payload.json http://localhost:8080/api/orders | jq
+
+# Retrieve orders from DB using the app API
+$ curl --header "Content-Type: application/json" \
+       http://localhost:8080/api/orders | jq
+```
+
+Verify the data stored in the PostgreSQL DB to be encrypted:
+
+```shell
+# Check the 'orders' table in PostgreSQL DB
+[vagrant@demo ~]$ docker exec -it postgres psql -U postgres -d postgres
+
+postgres# select * from orders;
+id |                     customer_name                     | product_name |       order_date
+----+-------------------------------------------------------+--------------+-------------------------
+ 1 | vault:v1:Qj0lx5DSZvwcHeMOX/5UX/ErHTaDPA3mVlSSpaXd1tbM | VE           | 2018-04-18 21:56:37.924
+ 2 | vault:v1:UwL3HnyqTUac5ElS5WYAuNg3NdIMFtd6vvwukL+FaKun | Nomad        | 2018-04-18 22:07:42.916
+(2 rows)
+
+postgres# \q
 ```


### PR DESCRIPTION
This guide is now [published](https://www.vaultproject.io/guides/encryption/spring-demo.html).  The reference to the new guide has been added to point the audience. 