### PR TITLE
Updating for Vault 1.0

### DIFF
--- a/operations/aws-kms-unseal/terraform-aws/README.md
+++ b/operations/aws-kms-unseal/terraform-aws/README.md
@@ -35,11 +35,8 @@ $ vault status
 # Initialize Vault
 $ vault operator init -stored-shares=1 -recovery-shares=1 -recovery-threshold=1 -key-shares=1 -key-threshold=1
 
-# Stop the Vault server
-$ sudo systemctl stop vault
-
 # Restart the Vault server
-$ sudo systemctl start vault
+$ sudo systemctl restart vault
 
 # Check to verify that the Vault is auto-unsealed
 $ vault status

--- a/operations/aws-kms-unseal/terraform-aws/README.md
+++ b/operations/aws-kms-unseal/terraform-aws/README.md
@@ -1,6 +1,6 @@
 # Vault Auto-unseal using AWS KMS
 
-These assets are provided to perform the tasks described in the [Vault Auto-unseal with AWS KMS](https://www.vaultproject.io/guides/operations/autounseal-aws-kms.html) guide.
+These assets are provided to perform the tasks described in the [Vault Auto-unseal with AWS KMS](https://learn.hashicorp.com/vault/operations/ops-autounseal-aws-kms) guide.
 
 ---
 

--- a/operations/aws-kms-unseal/terraform-aws/instance.tf
+++ b/operations/aws-kms-unseal/terraform-aws/instance.tf
@@ -65,7 +65,7 @@ data "template_file" "format_ssh" {
 output "connections" {
   value = <<VAULT
 Connect to Vault via SSH   ssh ubuntu@${aws_instance.vault.public_ip} -i private.key
-Vault Enterprise web interface  http://${aws_instance.vault.public_ip}:8200/ui
+Vault web interface  http://${aws_instance.vault.public_ip}:8200/ui
 VAULT
 }
 

--- a/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
+++ b/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
@@ -1,1 +1,1 @@
-vault_url = "http://s3.amazonaws.com/some/path/to/vault-enterprise.zip"
+vault_url = "https://releases.hashicorp.com/vault/1.0.0-beta1/vault_1.0.0-beta1_linux_amd64.zip"

--- a/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
+++ b/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
@@ -1,1 +1,1 @@
-vault_url = "https://releases.hashicorp.com/vault/1.0.0-beta1/vault_1.0.0-beta1_linux_amd64.zip"
+vault_url = "https://releases.hashicorp.com/vault/1.0.0-beta2/vault_1.0.0-beta2_linux_amd64.zip"


### PR DESCRIPTION
[Vault 1.0 beta](https://releases.hashicorp.com/vault/1.0.0-beta1/) is already out for people to try.  So, I want to update this example to use Vault 1.0 as well.  

FYI:  A guide for [GCP Cloud KMS](https://learn.hashicorp.com/vault/operations/autounseal-gcp-kms) has been published already. 