### PR TITLE
Updated the Vagranfile to pull vault:latest image

### DIFF
--- a/secrets/spring-cloud-vault/vagrant-local/Vagrantfile
+++ b/secrets/spring-cloud-vault/vagrant-local/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure("2") do |config|
       d.run "postgres",
         args: "--net=host -d"
       d.run "vault",
-        image: "vault:0.10.0",
+        image: "vault:latest",
         args: "--net=host --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' -d"
       d.run "spring",
         args: "--net=host -v /vagrant/bootstrap.yaml:/bootstrap.yaml -e 'VAULT_TOKEN=root' -d"


### PR DESCRIPTION
I tested and verified that everything works with `vault:latest` docker image (which is currently Vault 0.11.4). 

For the purpose of [education](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-spring-demo), can we change the Vagrantfile to pull the latest image?  People might want to play around with the vault environment, so it would be nice to run the latest. 