### PR TITLE
Adds region to Vault AWS unseal block

### DIFF
--- a/operations/aws-kms-unseal/terraform-aws/userdata.tpl
+++ b/operations/aws-kms-unseal/terraform-aws/userdata.tpl
@@ -103,6 +103,7 @@ listener "tcp" {
   tls_disable = 1
 }
 seal "awskms" {
+  region     = "${aws_region}"
   kms_key_id = "${kms_key}"
 }
 ui=true


### PR DESCRIPTION
* Otherwise it’ll fail outside of us-east-1 
* Example: 

```
error fetching AWS KMS sealkey information: NotFoundException: Key 'arn:aws:kms:us-east-1:729476260648:key/d9e04345-f2c1-441e-9936-b00be5e0c7af' does not exist
```