### PR TITLE
[Learn] Upgrade Vault version to 1.0

### DIFF
--- a/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
+++ b/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
@@ -1,1 +1,1 @@
-vault_url = "https://releases.hashicorp.com/vault/1.0.0-rc1/vault_1.0.0-rc1_linux_amd64.zip"
+vault_url = "https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip"

--- a/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
+++ b/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
@@ -1,1 +1,4 @@
 vault_url = "https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip"
+
+aws_region = "us-west-1"
+aws_zone = "us-west-1a"

--- a/operations/aws-kms-unseal/terraform-aws/variables.tf
+++ b/operations/aws-kms-unseal/terraform-aws/variables.tf
@@ -7,7 +7,7 @@ variable aws_zone {
 }
 
 variable vault_url {
-  default = "https://releases.hashicorp.com/vault/1.0.0-rc1/vault_1.0.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip"
 }
 
 variable vpc_cidr {

--- a/operations/gcp-kms-unseal/variables.tf
+++ b/operations/gcp-kms-unseal/variables.tf
@@ -1,5 +1,5 @@
 variable vault_url {
-  default = "https://releases.hashicorp.com/vault/1.0.0-rc1/vault_1.0.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip"
 }
 
 variable gcloud-project {


### PR DESCRIPTION
Changing `https://releases.hashicorp.com/vault/1.0.0-rc1/vault_1.0.0-rc1_linux_amd64.zip` to `https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip`