### PR TITLE
[Learn] Fixed out-dated version & links

### DIFF
--- a/encryption/vault-transit-rewrap/README.md
+++ b/encryption/vault-transit-rewrap/README.md
@@ -1,6 +1,6 @@
 # Vault Transit Rewrap Record After Key Rotation Example
 
-These assets are provided to perform the tasks described in the [Transit Secret Re-wrapping](https://www.vaultproject.io/guides/encryption/transit-rewrap.html) guide.
+These assets are provided to perform the tasks described in the [Transit Secret Re-wrapping](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit-rewrap) guide.
 
 ---
 

--- a/identity/vault-agent-demo/terraform-aws/variables.tf
+++ b/identity/vault-agent-demo/terraform-aws/variables.tf
@@ -23,7 +23,7 @@ variable vault_server_count {
 
 # URL for Vault OSS binary
 variable vault_zip_file {
-    default = "https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip"
+    default = "https://releases.hashicorp.com/vault/1.0.1/vault_1.0.1_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary

--- a/identity/vault-agent-k8s-demo/README.md
+++ b/identity/vault-agent-k8s-demo/README.md
@@ -1,6 +1,6 @@
 # Vault Agent with Kubernetes
 
-These assets are provided to perform the steps described in the [Vault Agent with Kubernetes](https://deploy-preview-290--hashicorp-learn.netlify.com/vault/identity-access-management/vault-agent-k8s) guide.
+These assets are provided to perform the steps described in the [Vault Agent with Kubernetes](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-k8s) guide.
 
 ---
 

--- a/identity/vault-chef-approle/README.md
+++ b/identity/vault-chef-approle/README.md
@@ -1,6 +1,6 @@
 # Vault AppRole With Terraform & Chef Demo
 
-These assets are provided to perform the tasks described in the [Vault AppRole with Terraform and Chef Demo](https://www.vaultproject.io/guides/identity/approle-trusted-entities.html) guide.
+These assets are provided to perform the tasks described in the [Vault AppRole with Terraform and Chef Demo](https://learn.hashicorp.com/vault/identity-access-management/iam-approle-trusted-entities) guide.
 
 
 ----

--- a/identity/vault-chef-approle/terraform-aws/mgmt-node/terraform.tfvars.example
+++ b/identity/vault-chef-approle/terraform-aws/mgmt-node/terraform.tfvars.example
@@ -7,7 +7,7 @@ environment_name = "vault-chef-approle-demo"
 s3_bucket_name = "my-s3-bucket-name"
 
 # URL for Vault (open source) zip file
-vault_zip_url = "https://releases.hashicorp.com/vault/0.9.5/vault_0.9.5_linux_amd64.zip"
+vault_zip_url = "https://releases.hashicorp.com/vault/1.0.1/vault_1.0.1_linux_amd64.zip"
 
 # Instance size
 instance_type = "t2.medium"

--- a/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
+++ b/operations/aws-kms-unseal/terraform-aws/terraform.tfvars.example
@@ -1,4 +1,4 @@
-vault_url = "https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip"
+vault_url = "https://releases.hashicorp.com/vault/1.0.1/vault_1.0.1_linux_amd64.zip"
 
 aws_region = "us-west-1"
 aws_zone = "us-west-1a"

--- a/operations/gcp-kms-unseal/variables.tf
+++ b/operations/gcp-kms-unseal/variables.tf
@@ -1,5 +1,5 @@
 variable vault_url {
-  default = "https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.0.1/vault_1.0.1_linux_amd64.zip"
 }
 
 variable gcloud-project {

--- a/secrets/pki/vagrant/README.md
+++ b/secrets/pki/vagrant/README.md
@@ -29,7 +29,7 @@ Infosec will create ACLs, roles and tie together auth methods to policies.   The
 
 
 ## Challenge
-Using a vagrant image: 
+Using a vagrant image:
   * Start a minimal Vault/Consul cluster
   * Bootstrap the cluster to be secured with PKI certificates for internode communication
   * Create a short-lived TTL PKI Cert.  See it expire
@@ -55,7 +55,7 @@ Run a set of provisioning scripts against your Vault cluster.  This will create:
 
 ## Steps
 
-### Step 1: Clone this repo 
+### Step 1: Clone this repo
 ```
 git clone git@github.com:hashicorp/vault-guides.git
 ```
@@ -97,7 +97,7 @@ If you're using this guide over time, you may see messages like the following:
 ==> core-01: available! You currently have version '1745.4.0'. The latest is version
 ==> core-01: '1745.5.0'. Run `vagrant box update` to update.
 ```
-It's best to run the update so CoreOS functions properly. 
+It's best to run the update so CoreOS functions properly.
 
 ```
 vagrant box update
@@ -145,7 +145,7 @@ sudo /demo/demo2_short_ttls.sh
 This demostration renews the certificate that's not invalid on a regular basis. You should now see the certificate is valid in the window running demo2.  Leave this running in this window
 
 ```
-sudo /demo/demo3_renew_lease.sh 
+sudo /demo/demo3_renew_lease.sh
 ```
 
 ### Step 10: Run demo4_revoke_cert.sh in another window
@@ -175,7 +175,7 @@ After running this for 2-3 minutes (or however long you want), stop the demo usi
 
 **NOTE**
 
-Vault doesn't have the concept of blocking queries like Consul does.   This means that it doesn't have the capabilities of noticing changes to a particular secret you are monitoring.  However, in the case of PKI certs, consul-template will renew based on the lease for the certificate.   Keep this in mind of you're trying to use consul-template for automating retrieval of other Vault secrets. 
+Vault doesn't have the concept of blocking queries like Consul does.   This means that it doesn't have the capabilities of noticing changes to a particular secret you are monitoring.  However, in the case of PKI certs, consul-template will renew based on the lease for the certificate.   Keep this in mind of you're trying to use consul-template for automating retrieval of other Vault secrets.
 
 ### Step 12: Tear down the guide
 Congratulations!  You've taken a step into the wonderful world of PKI Provisioning with Vault!   To be complete, clean up your guide environment.   Also, remember that vagrant will ask for your sudo password to remove NFS entries from /etc/exports:

--- a/secrets/spring-cloud-vault/README.md
+++ b/secrets/spring-cloud-vault/README.md
@@ -1,6 +1,6 @@
 # Java Sample App using Spring Cloud Vault
 
-These assets are provided to perform the tasks described in the [Java Sample App using Spring Cloud Vault](https://www.vaultproject.io/guides/encryption/spring-demo.html) guide.
+These assets are provided to perform the tasks described in the [Java Application Demo](https://learn.hashicorp.com/vault/developer/eaas-spring-demo) guide.
 
 
 Originally, this app was demonstrated during the [Manage secrets, access, and encryption in the public cloud


### PR DESCRIPTION
Due to the transition to the `learn` platform, some of the links in the README were out-dated.  They are now directed to the correct location. 

Also, updated the `vault` binary link to `1.0.1`.