### PR TITLE
[WIP] Terraform to provision Azure Key Vault and Key

### DIFF
--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -52,7 +52,7 @@ To successfully execute this guide, you would need the following:
 
 1. Vault server configuration file (`config.hcl`) should look like:
 
-    ```
+    ```text
     ui = true
 
     storage "consul" {

--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -1,4 +1,4 @@
-# Vault Auto-unseal using Azure Key Vault
+# Auto-unseal using Azure Key Vault
 
 These assets are provided to perform the tasks described in the [Auto-unseal with Azure Key Vault](https://deploy-preview-346--hashicorp-learn.netlify.com/vault/operations/autounseal-azure-keyvault) guide.
 
@@ -40,7 +40,7 @@ Tips:
 
 1. Set this location as your working directory
 
-1. Provide tenant ID in the `terraform.tfvars.example` and save it as `terraform.tfvars`
+1. Provide Azure credentials in the `terraform.tfvars.example` and save it as `terraform.tfvars`
 
     > NOTE: Overwrite the Azure `location` or `environment` name in the `terraform.tfvars` as desired.
 
@@ -61,8 +61,6 @@ Tips:
     key_vault_name = Test-vault-a414d041
     ssh_link = ssh azureuser@52.168.108.142
     ```
-
-    Notice that the generated Azure Key Vault name is displayed (e.g. `Test-vault-cc6092c7`).
 
 1. SSH into the virtual machine:
 
@@ -91,7 +89,7 @@ Tips:
 1. Initialize Vault
 
     ```plaintext
-    $ vault operator init -key-shares=1 -key-threshold=1
+    $ vault operator init 
     ```
 
 1. Stop and start the Vault server

--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -66,7 +66,7 @@ Tips:
     key_vault_name = Test-vault-cc6092c7
     ```
 
-    Notice that the generated Azure Key Vault name is displayed (e.g. `Test-vault-cc6092c7`). 
+    Notice that the generated Azure Key Vault name is displayed (e.g. `Test-vault-cc6092c7`).
 
 1. Vault server configuration file (`config.hcl`) should look like:
 
@@ -84,9 +84,9 @@ Tips:
     }
 
     seal "azurekeyvault" {
-      client_id="AZURE_CLIENT_ID"
-      client_secret = "AZURE_CLIENT_SECRET"
-      tenant_id="AZURE_TENANT_IDc"
+      client_id      = "AZURE_CLIENT_ID"
+      client_secret  = "AZURE_CLIENT_SECRET"
+      tenant_id      = "AZURE_TENANT_IDc"
       vault_name     = "Test-vault-xxxxx"
       key_name       = "generated-key"
     }

--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -1,0 +1,76 @@
+# Vault Auto-unseal using Azure Key Vault
+
+These assets are provided to perform the tasks described in the Auto-unseal with Azure Key Vault guide which is being developed.
+
+---
+
+## Prerequisites
+
+- Microsoft Azure account
+- [Terraform installed](https://www.terraform.io/downloads.html) and ready to use
+
+**Terraform Azure Provider Prerequisites**
+
+A ***service principal*** is an application within Azure Active Directory which
+can be used to authenticate. Service principals are preferable to running an app
+using your own credentials. Follow the instruction in the [Terraform
+documentation](https://www.terraform.io/docs/providers/azurerm/auth/service_principal_client_certificate.html)
+to create a service principal and then configure in Terraform.
+
+To successfully execute this guide, you would need the following:
+
+- **Tenant ID**: Navigate to the [Azure Active Directory >
+ Properties](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Properties)
+ in the Azure Portal, and copy the **Directory ID** which is your tenant ID  
+
+- **Client ID**: Same as the [**Application
+ ID**](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ApplicationsListBlade)
+
+- **Client secret**: The [password
+ (credential)](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ApplicationsListBlade)
+ set on your application
+
+## Steps
+
+1. Set this location as your working directory
+
+1. Provide tenant ID in the `terraform.tfvars.example` and save it as `terraform.tfvars`.
+    NOTE: Overwrite the Azure `location` or `environment` name in the `terraform.tfvars` as desired.
+
+1. Run the Terraform commands:
+
+    ```shell
+    # Pull necessary plugins
+    $ terraform init
+
+    $ terraform plan
+
+    # Output provides the SSH instruction
+    $ terraform apply -auto-approve
+    ```
+
+1. Vault server configuration file (`config.hcl`) should look like:
+
+```
+ui = true
+
+storage "consul" {
+  address = "127.0.0.1:8500"
+  path = "vault"
+}
+
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = 1
+}
+
+seal "azurekeyvault" {
+  client_id="AZURE_CLIENT_ID"
+  client_secret = "AZURE_CLIENT_SECRET"
+  tenant_id="AZURE_TENANT_IDc"
+  vault_name     = "Test-vault-xxxxx"
+  key_name       = "generated-key"
+}
+
+disable_mlock = true
+```

--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -9,6 +9,8 @@ These assets are provided to perform the tasks described in the Auto-unseal with
 - Microsoft Azure account
 - [Terraform installed](https://www.terraform.io/downloads.html) and ready to use
 
+<br>
+
 **Terraform Azure Provider Prerequisites**
 
 A ***service principal*** is an application within Azure Active Directory which
@@ -17,7 +19,17 @@ using your own credentials. Follow the instruction in the [Terraform
 documentation](https://www.terraform.io/docs/providers/azurerm/auth/service_principal_client_certificate.html)
 to create a service principal and then configure in Terraform.
 
-To successfully execute this guide, you would need the following:
+Tips:
+
+- **Subscription ID**: Navigate to the [Subscriptions blade within the Azure
+ Portal](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade)
+ and copy the **Subscription ID**  
+
+    > **NOTE**: Be sure to set the ARM_SUBSCRIPTION_ID environment variable
+
+    ```text
+    $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
+    ```
 
 - **Tenant ID**: Navigate to the [Azure Active Directory >
  Properties](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Properties)
@@ -48,7 +60,13 @@ To successfully execute this guide, you would need the following:
 
     # Output provides the SSH instruction
     $ terraform apply -auto-approve
+    ...
+    Outputs:
+
+    key_vault_name = Test-vault-cc6092c7
     ```
+
+    Notice that the generated Azure Key Vault name is displayed (e.g. `Test-vault-cc6092c7`). 
 
 1. Vault server configuration file (`config.hcl`) should look like:
 

--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -34,8 +34,9 @@ To successfully execute this guide, you would need the following:
 
 1. Set this location as your working directory
 
-1. Provide tenant ID in the `terraform.tfvars.example` and save it as `terraform.tfvars`.
-    NOTE: Overwrite the Azure `location` or `environment` name in the `terraform.tfvars` as desired.
+1. Provide tenant ID in the `terraform.tfvars.example` and save it as `terraform.tfvars`
+
+    > NOTE: Overwrite the Azure `location` or `environment` name in the `terraform.tfvars` as desired.
 
 1. Run the Terraform commands:
 
@@ -51,26 +52,26 @@ To successfully execute this guide, you would need the following:
 
 1. Vault server configuration file (`config.hcl`) should look like:
 
-```
-ui = true
+    ```
+    ui = true
 
-storage "consul" {
-  address = "127.0.0.1:8500"
-  path = "vault"
-}
+    storage "consul" {
+      address = "127.0.0.1:8500"
+      path = "vault"
+    }
 
-listener "tcp" {
-  address     = "127.0.0.1:8200"
-  tls_disable = 1
-}
+    listener "tcp" {
+      address     = "127.0.0.1:8200"
+      tls_disable = 1
+    }
 
-seal "azurekeyvault" {
-  client_id="AZURE_CLIENT_ID"
-  client_secret = "AZURE_CLIENT_SECRET"
-  tenant_id="AZURE_TENANT_IDc"
-  vault_name     = "Test-vault-xxxxx"
-  key_name       = "generated-key"
-}
+    seal "azurekeyvault" {
+      client_id="AZURE_CLIENT_ID"
+      client_secret = "AZURE_CLIENT_SECRET"
+      tenant_id="AZURE_TENANT_IDc"
+      vault_name     = "Test-vault-xxxxx"
+      key_name       = "generated-key"
+    }
 
-disable_mlock = true
-```
+    disable_mlock = true
+    ```

--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -1,6 +1,6 @@
 # Vault Auto-unseal using Azure Key Vault
 
-These assets are provided to perform the tasks described in the Auto-unseal with Azure Key Vault guide which is being developed.
+These assets are provided to perform the tasks described in the [Auto-unseal with Azure Key Vault](https://deploy-preview-346--hashicorp-learn.netlify.com/vault/operations/autounseal-azure-keyvault) guide.
 
 ---
 

--- a/operations/azure-keyvault-unseal/README.md
+++ b/operations/azure-keyvault-unseal/README.md
@@ -25,12 +25,6 @@ Tips:
  Portal](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade)
  and copy the **Subscription ID**  
 
-    > **NOTE**: Be sure to set the ARM_SUBSCRIPTION_ID environment variable
-
-    ```text
-    $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
-    ```
-
 - **Tenant ID**: Navigate to the [Azure Active Directory >
  Properties](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Properties)
  in the Azure Portal, and copy the **Directory ID** which is your tenant ID  

--- a/operations/azure-keyvault-unseal/main.tf
+++ b/operations/azure-keyvault-unseal/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_key_vault" "vault" {
     object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
 
     certificate_permissions = [
-      "get", 
+      "get",
       "list",
       "create",
       "delete",
@@ -83,8 +83,4 @@ resource "azurerm_key_vault_key" "generated" {
 
 output "key_vault_name" {
   value = "${azurerm_key_vault.vault.name}"
-}
-
-output "object_id" {
-  value = "${data.azurerm_client_config.current.service_principal_object_id}"
 }

--- a/operations/azure-keyvault-unseal/main.tf
+++ b/operations/azure-keyvault-unseal/main.tf
@@ -3,6 +3,10 @@ provider "azurerm" {}
 resource "azurerm_resource_group" "vault" {
   name     = "${var.environment}-vault-rg"
   location = "${var.location}"
+
+  tags {
+    environment = "${var.environment}"
+  }
 }
 
 resource "random_id" "keyvault" {
@@ -33,7 +37,7 @@ resource "azurerm_key_vault" "vault" {
     object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
 
     certificate_permissions = [
-      "get",
+      "get", 
       "list",
       "create",
       "delete",
@@ -66,7 +70,7 @@ resource "azurerm_key_vault" "vault" {
 
 
 resource "azurerm_key_vault_key" "generated" {
-  name      = "generated-key"
+  name      = "${var.key_name}"
   vault_uri = "${azurerm_key_vault.vault.vault_uri}"
   key_type  = "RSA"
   key_size  = 2048
@@ -83,4 +87,196 @@ resource "azurerm_key_vault_key" "generated" {
 
 output "key_vault_name" {
   value = "${azurerm_key_vault.vault.name}"
+}
+
+
+# ---------------------
+# Create Vault VM
+# ---------------------
+resource "azurerm_virtual_network" "tf_network" {
+    name                = "network-${random_id.keyvault.hex}"
+    address_space       = ["10.0.0.0/16"]
+    location            = "${var.location}"
+    resource_group_name = "${azurerm_resource_group.vault.name}"
+
+    tags {
+        environment = "${var.environment}-${random_id.keyvault.hex}"
+    }
+}
+
+resource "azurerm_subnet" "tf_subnet" {
+    name                 = "subnet-${random_id.keyvault.hex}"
+    resource_group_name  = "${azurerm_resource_group.vault.name}"
+    virtual_network_name = "${azurerm_virtual_network.tf_network.name}"
+    address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_public_ip" "tf_publicip" {
+    name                         = "ip-${random_id.keyvault.hex}"
+    location                     = "${var.location}"
+    resource_group_name          = "${azurerm_resource_group.vault.name}"
+    public_ip_address_allocation = "dynamic"
+
+    tags {
+        environment = "${var.environment}-${random_id.keyvault.hex}"
+    }
+}
+
+resource "azurerm_network_security_group" "tf_nsg" {
+    name                = "nsg-${random_id.keyvault.hex}"
+    location            = "${var.location}"
+    resource_group_name = "${azurerm_resource_group.vault.name}"
+
+    security_rule {
+        name                       = "SSH"
+        priority                   = 1001
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+
+    security_rule {
+        name                       = "Vault"
+        priority                   = 1002
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "8200"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+
+    security_rule {
+        name                       = "Consul"
+        priority                   = 1003
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "8500"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+
+    tags {
+        environment = "${var.environment}-${random_id.keyvault.hex}"
+    }
+}
+
+resource "azurerm_network_interface" "tf_nic" {
+    name                      = "nic-${random_id.keyvault.hex}"
+    location                  = "${var.location}"
+    resource_group_name       = "${azurerm_resource_group.vault.name}"
+    network_security_group_id = "${azurerm_network_security_group.tf_nsg.id}"
+
+    ip_configuration {
+        name                          = "nic-${random_id.keyvault.hex}"
+        subnet_id                     = "${azurerm_subnet.tf_subnet.id}"
+        private_ip_address_allocation = "dynamic"
+        public_ip_address_id          = "${azurerm_public_ip.tf_publicip.id}"
+    }
+
+    tags {
+        environment = "${var.environment}-${random_id.keyvault.hex}"
+    }
+}
+
+resource "random_id" "tf_random_id" {
+    keepers = {
+        # Generate a new ID only when a new resource group is defined
+        resource_group = "${azurerm_resource_group.vault.name}"
+    }
+
+    byte_length = 8
+}
+
+resource "azurerm_storage_account" "tf_storageaccount" {
+    name                        = "sa${random_id.keyvault.hex}"
+    resource_group_name         = "${azurerm_resource_group.vault.name}"
+    location                    = "${var.location}"
+    account_tier                = "Standard"
+    account_replication_type    = "LRS"
+
+    tags {
+        environment = "${var.environment}-${random_id.keyvault.hex}"
+    }
+}
+
+data "template_file" "setup" {
+  template = "${file("${path.module}/setup.tpl")}"
+
+  vars = {
+    resource_group_name = "${var.resource_group_name}"
+    vm_name = "${var.vm_name}"
+    vault_download_url = "${var.vault_download_url}"
+    tenant_id = "${var.tenant_id}"
+    subscription_id = "${var.subscription_id}"
+    client_id = "${var.client_id}"
+    client_secret = "${var.client_secret}"
+    vault_name = "${azurerm_key_vault.vault.name}"
+    key_name = "${var.key_name}"
+  }
+}
+
+# Create virtual machine
+resource "azurerm_virtual_machine" "tf_vm" {
+    name                  = "${var.vm_name}"
+    location              = "${var.location}"
+    resource_group_name   = "${azurerm_resource_group.vault.name}"
+    network_interface_ids = ["${azurerm_network_interface.tf_nic.id}"]
+    vm_size               = "Standard_DS1_v2"
+    
+    identity = {
+      type = "SystemAssigned"
+    }
+
+    storage_os_disk {
+        name              = "OsDisk"
+        caching           = "ReadWrite"
+        create_option     = "FromImage"
+        managed_disk_type = "Premium_LRS"
+    }
+
+    storage_image_reference {
+        publisher = "Canonical"
+        offer     = "UbuntuServer"
+        sku       = "16.04.0-LTS"
+        version   = "latest"
+    }
+
+    os_profile {
+        computer_name  = "${var.vm_name}"
+        admin_username = "azureuser"
+        custom_data = "${data.template_file.setup.rendered}"
+    }
+
+    os_profile_linux_config {
+        disable_password_authentication = true
+        ssh_keys {
+            path     = "/home/azureuser/.ssh/authorized_keys"
+            key_data = "${var.public_key}"
+        }
+    }
+
+    boot_diagnostics {
+        enabled = "true"
+        storage_uri = "${azurerm_storage_account.tf_storageaccount.primary_blob_endpoint}"
+    }
+
+    tags {
+        environment = "${var.environment}-${random_id.keyvault.hex}"
+    }
+}
+
+output "ip" {
+    value = "${azurerm_public_ip.tf_publicip.ip_address}"
+}
+
+output "ssh_link" {
+    value = "ssh azureuser@${azurerm_public_ip.tf_publicip.ip_address}"
 }

--- a/operations/azure-keyvault-unseal/main.tf
+++ b/operations/azure-keyvault-unseal/main.tf
@@ -1,0 +1,90 @@
+provider "azurerm" {}
+
+resource "azurerm_resource_group" "vault" {
+  name     = "${var.environment}-vault-rg"
+  location = "${var.location}"
+}
+
+resource "random_id" "keyvault" {
+  byte_length = 4
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "vault" {
+  name                        = "${var.environment}-vault-${random_id.keyvault.hex}"
+  location                    = "${azurerm_resource_group.vault.location}"
+  resource_group_name         = "${azurerm_resource_group.vault.name}"
+  enabled_for_deployment      = true
+  enabled_for_disk_encryption = true
+  tenant_id                   = "${var.tenant_id}"
+
+  sku {
+    name = "standard"
+  }
+
+  tags {
+    environment = "${var.environment}"
+  }
+
+  access_policy {
+    tenant_id = "${var.tenant_id}"
+    #object_id = "${var.object_id}"
+    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+
+    certificate_permissions = [
+      "get", 
+      "list",
+      "create",
+      "delete",
+      "update",
+    ]
+
+    key_permissions = [
+      "get",
+      "list",
+      "create",
+      "delete",
+      "update",
+      "wrapKey",
+      "unwrapKey",
+    ]
+
+    secret_permissions = [
+      "get",
+      "list",
+      "set",
+      "delete",
+    ]
+  }
+
+  network_acls {
+    default_action = "Allow"
+    bypass         = "AzureServices"
+  }
+}
+
+
+resource "azurerm_key_vault_key" "generated" {
+  name      = "generated-key"
+  vault_uri = "${azurerm_key_vault.vault.vault_uri}"
+  key_type  = "RSA"
+  key_size  = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+output "key_vault_name" {
+  value = "${azurerm_key_vault.vault.name}"
+}
+
+output "object_id" {
+  value = "${data.azurerm_client_config.current.service_principal_object_id}"
+}

--- a/operations/azure-keyvault-unseal/setup.tpl
+++ b/operations/azure-keyvault-unseal/setup.tpl
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+sudo apt-get install -y unzip jq 
+
+VAULT_ZIP="vault.zip"
+VAULT_URL="${vault_download_url}"
+curl --silent --output /tmp/$${VAULT_ZIP} $${VAULT_URL}
+unzip -o /tmp/$${VAULT_ZIP} -d /usr/local/bin/
+chmod 0755 /usr/local/bin/vault
+chown vault:vault /usr/local/bin/vault
+mkdir -pm 0755 /etc/vault.d
+mkdir -pm 0755 /opt/vault
+chown azureuser:azureuser /opt/vault
+
+export VAULT_ADDR=http://127.0.0.1:8200
+
+cat << EOF > /lib/systemd/system/vault.service
+[Unit]
+Description=Vault Agent
+Requires=network-online.target
+After=network-online.target
+[Service]
+Restart=on-failure
+PermissionsStartOnly=true
+ExecStartPre=/sbin/setcap 'cap_ipc_lock=+ep' /usr/local/bin/vault
+ExecStart=/usr/local/bin/vault server -config /etc/vault.d
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+User=azureuser
+Group=azureuser
+[Install]
+WantedBy=multi-user.target
+EOF
+
+
+cat << EOF > /etc/vault.d/config.hcl
+storage "file" {
+  path = "/opt/vault"
+}
+listener "tcp" {
+  address     = "0.0.0.0:8200"
+  tls_disable = 1
+}
+seal "azurekeyvault" {
+  client_id      = "${client_id}"
+  client_secret  = "${client_secret}"
+  tenant_id      = "${tenant_id}"
+  vault_name     = "${vault_name}"
+  key_name       = "${key_name}"
+}
+ui=true
+disable_mlock = true
+EOF
+
+
+sudo chmod 0664 /lib/systemd/system/vault.service
+systemctl daemon-reload
+sudo chown -R vault:vault /etc/vault.d
+sudo chmod -R 0644 /etc/vault.d/*
+
+cat << EOF > /etc/profile.d/vault.sh
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_SKIP_VERIFY=true
+EOF
+
+systemctl enable vault
+systemctl start vault
+
+
+sudo cat << EOF > /tmp/azure_auth.sh
+set -v
+export VAULT_ADDR="http://127.0.0.1:8200"
+
+vault write auth/azure/login role="dev-role" \
+  jwt="$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F'  -H Metadata:true -s | jq -r .access_token)" \
+  subscription_id="${subscription_id}" \
+  resource_group_name="${resource_group_name}" \
+  vm_name="${vm_name}"
+EOF
+
+sudo chmod +x /tmp/azure_auth.sh

--- a/operations/azure-keyvault-unseal/terraform.tfvars.example
+++ b/operations/azure-keyvault-unseal/terraform.tfvars.example
@@ -1,9 +1,21 @@
 # Provide your tenant ID (Required)
 tenant_id="YOUR_TENANT_ID"
 
+# Public SSH key (Required)
+public_key = "ssh-rsa <rsa_public_key>"
+
+# Azure Client ID (Required)
+client_id = "AZURE-APP-ID"
+
+# Azure Client secret (Required)
+client_secret = "AZURE-APP-PASSWORD"
+
+# Azure account subscription ID (Required)
+subscription_id = "YOUR-AZURE-SUBSCRIPTION-ID"
+
 
 # To overwrite the default (Optional)
 location="westus"
 
 # To overwrite the default (Optional)
-environment = "autounseal"
+environment = "test"

--- a/operations/azure-keyvault-unseal/terraform.tfvars.example
+++ b/operations/azure-keyvault-unseal/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Provide your tenant ID
+tenant_id="ARM_TENANT_ID"
+
+# To overwrite the default 
+location="westus"

--- a/operations/azure-keyvault-unseal/terraform.tfvars.example
+++ b/operations/azure-keyvault-unseal/terraform.tfvars.example
@@ -1,5 +1,9 @@
-# Provide your tenant ID
-tenant_id="ARM_TENANT_ID"
+# Provide your tenant ID (Required)
+tenant_id="YOUR_TENANT_ID"
 
-# To overwrite the default 
+
+# To overwrite the default (Optional)
 location="westus"
+
+# To overwrite the default (Optional)
+environment = "autounseal"

--- a/operations/azure-keyvault-unseal/variables.tf
+++ b/operations/azure-keyvault-unseal/variables.tf
@@ -1,7 +1,14 @@
+# ---------------------------
+# Azure Key Vault
+# ---------------------------
 variable "tenant_id" {
     default = ""
 }
 
+variable "key_name" {
+    description = "Azure Key Vault key name"
+    default = "generated-key"
+}
 variable "location" {
     description = "Azure location where the Key Vault resource to be created"
     default = "eastus"
@@ -9,4 +16,35 @@ variable "location" {
 
 variable "environment" {
     default = "Test"
+}
+
+# ---------------------------
+# Virtual Machine
+# ---------------------------
+variable "public_key" {
+  default = ""
+}
+
+variable "subscription_id" {
+    default = ""
+}
+
+variable "client_id" {
+    default = ""
+}
+
+variable "client_secret" {
+    default = ""
+}
+
+variable "vm_name" {
+    default = "azure-auth-demo-vm"
+}
+
+variable "vault_download_url" {
+    default = "https://releases.hashicorp.com/vault/1.0.2/vault_1.0.2_linux_amd64.zip"
+}
+
+variable "resource_group_name" {
+    default = "vault-demo-azure-auth"
 }

--- a/operations/azure-keyvault-unseal/variables.tf
+++ b/operations/azure-keyvault-unseal/variables.tf
@@ -1,0 +1,12 @@
+variable "tenant_id" {
+    default = ""
+}
+
+variable "location" {
+    description = "Azure location where the Key Vault resource to be created"
+    default = "eastus"
+}
+
+variable "environment" {
+    default = "Test"
+}


### PR DESCRIPTION
For the moment, the `main.tf` generates an instance of Azure Key Vault (`Test-vault-xxxxx`) and a key (`generated-key`) which is enough to auto-unseal your local Vault server. 

What I need to add is a VM with:

- [x]  Vault installed
- [x]  Vault configuration file (`config.hcl`) with `seal` stanza
- [x]  Vault service files (`systemd`)