### PR TITLE
Changes to Azure autounseal

### DIFF
--- a/operations/azure-keyvault-unseal/main.tf
+++ b/operations/azure-keyvault-unseal/main.tf
@@ -115,7 +115,7 @@ resource "azurerm_public_ip" "tf_publicip" {
     name                         = "ip-${random_id.keyvault.hex}"
     location                     = "${var.location}"
     resource_group_name          = "${azurerm_resource_group.vault.name}"
-    public_ip_address_allocation = "dynamic"
+    allocation_method            = "Dynamic"
 
     tags {
         environment = "${var.environment}-${random_id.keyvault.hex}"


### PR DESCRIPTION
Removes warning:

```
Warning: azurerm_public_ip.tf_publicip: "public_ip_address_allocation": [DEPRECATED] this property has been deprecated in favor of `allocation_method` to better match the api
```