### PR TITLE
Adding a workaround for known beta bug

### DIFF
--- a/identity/vault-agent-caching/terraform-aws/templates/userdata-vault-client.tpl
+++ b/identity/vault-agent-caching/terraform-aws/templates/userdata-vault-client.tpl
@@ -209,7 +209,7 @@ else
 fi
 
 sudo systemctl enable consul
-sudo systemctl start consul
+# sudo systemctl start consul
 
 ##--------------------------------------------------------------------
 ## Configure DNS Forwarding for Consul

--- a/identity/vault-agent-caching/terraform-aws/templates/userdata-vault-server.tpl
+++ b/identity/vault-agent-caching/terraform-aws/templates/userdata-vault-server.tpl
@@ -420,6 +420,9 @@ vault auth enable aws
 vault write -force auth/aws/config/client
 
 vault write auth/aws/role/app-role auth_type=iam bound_iam_principal_arn="arn:aws:iam::${account_id}:role/${role_name}" policies=myapp ttl=24h
+
+vault auth enable userpass
+vault write auth/userpass/users/student password="pAssw0rd" policies="myapp" ttl=48h
 EOF
 
 


### PR DESCRIPTION
In Vault 1.1-beta, if the request doesn't already contain a Vault token, then the auto-auth token will used to make requests. The resulting secrets from these auto-auth token calls are **not cached**. They will be in the non-beta version. To test out the caching scenarios, please make a login request or a token creation request via the agent. The secrets generated from these new tokens will get cached.