### PR TITLE
Fixed all out-dated URLs for Vault guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ----
 # Vault-Guides
 
-This repository provides the technical content to support the [Vault Guides](https://www.vaultproject.io/guides/index.html) site.
+This repository provides the technical content to support the [Vault learn](https://learn.hashicorp.com/vault/) site.
 
 ## Operations
 

--- a/encryption/vault-transit-rewrap/README.md
+++ b/encryption/vault-transit-rewrap/README.md
@@ -8,16 +8,16 @@ These assets are provided to perform the tasks described in the [Transit Secret 
 
 The following files are provided as demo scripts:
 
-- `demo_setup.sh` performs [Step 1 through 3](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#steps) in the guide
+- `demo_setup.sh` performs [Step 1 through 3](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit-rewrap) in the guide
   * Pull and run mysql server 5.7 docker container
   * Enable transit secret engine
   * Create `my_app_key` encryption key
   * Create `rewrap_example` policy
   * Generate a token to be used by the app
-- `run_app.sh` performs [Step 4](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#step4) in the guide
+- `run_app.sh` performs [Step 4](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit-rewrap) in the guide
   * Runs the example app
   * Prints out the commends to explore the MySQL DB
-- `rewrap_example.sh` performs [Step 5](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#step-5-rotate-the-encryption-keys) in the guide
+- `rewrap_example.sh` performs [Step 5](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit-rewrap) in the guide
   * Read the `my_app_key` details BEFORE the key rotation
   * Rotate the `my_app_key` encryption key
   * Read the `my_app_key` details AFTER the key rotation
@@ -27,7 +27,7 @@ The following files are provided as demo scripts:
 
 ### Demo Workflow
 
-> **NOTE:** DON'T FORGET that this demo requires [.NET Core and Docker](https://www.vaultproject.io/guides/encryption/transit-rewrap.html#prerequisites) to run the sample app.
+> **NOTE:** DON'T FORGET that this demo requires [.NET Core and Docker](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit-rewrap) to run the sample app.
 
 1. Run `demo_setup.sh`
 

--- a/identity/vault-chef-approle/README.md
+++ b/identity/vault-chef-approle/README.md
@@ -33,7 +33,7 @@ $ terraform apply
 
 ### AppRole Configuration
 
-Run the `/home/ubuntu/demo_setup.sh` script which performs ***Step 3*** through ***6*** in the [guide](https://www.vaultproject.io/guides/identity/approle-trusted-entities.html#steps).
+Run the `/home/ubuntu/demo_setup.sh` script which performs ***Step 3*** through ***6*** in the [guide](https://learn.hashicorp.com/vault/identity-access-management/iam-approle-trusted-entities).
 
 
 ### Chef Node

--- a/operations/lease-max-ttl-tuning/README.md
+++ b/operations/lease-max-ttl-tuning/README.md
@@ -52,7 +52,7 @@ export VAULT_ADDR=http://0.0.0.0:8200
 export VAULT_TOKEN=password
 
 # This will install, run and configure MySQL, and configure Vault to use the dynamic database credentials functionality
-cd /vagrant 
+cd /vagrant
 ./install-database.sh
 
 # Mount database backend
@@ -112,7 +112,7 @@ max_lease_ttl    	30 #<---------------------------------------------------------
 ```
 vault read database/creds/readonly
 
-# Output - see how now the lease duration is 30s, constrained by the new mount max_ttl. 
+# Output - see how now the lease duration is 30s, constrained by the new mount max_ttl.
 # Remember, the leases inside a mount cant be greater than either the mount or the system default.
 Key            	Value
 ---            	-----
@@ -142,7 +142,7 @@ _________________________________________
 ```
 vault read database/creds/readonly
 
-# Output - see how now the lease duration is 30s, constrained by the new mount max_ttl. 
+# Output - see how now the lease duration is 30s, constrained by the new mount max_ttl.
 # Remember, the leases inside a mount cant be greater than either the mount or the system default.
 Key            	Value
 ---            	-----
@@ -154,7 +154,7 @@ username       	v-read-hjuhjveyf
 ```
 ### Step 8: Change system max_lease_ttl:
 ```
-# Now let's change the system max_ttl, which is done in the Vault configuration file. 
+# Now let's change the system max_ttl, which is done in the Vault configuration file.
 # In order to do that, we need to first stop the process running vault:
  ps aux | grep vault
 # Output:
@@ -162,7 +162,7 @@ root      5266  0.0  4.8  62364 24224 ?        Sl   13:43   0:00 /usr/local/bin/
 # Now we kill the process:
 sudo kill -9 5266
 
-# Now edit your Vault config, reference for possible values here: https://www.vaultproject.io/docs/configuration/index.html. 
+# Now edit your Vault config, reference for possible values here: https://www.vaultproject.io/docs/configuration/index.html.
 # For example:
 -------------------------------------------
 vault.hcl:
@@ -212,7 +212,7 @@ lease_renewable	true
 password       	A1a-ss1z6s92v168qrv9
 username       	v-read-88rqxx3p0
 
-# Even though in the configuration we have 30 mins. 
+# Even though in the configuration we have 30 mins.
 vault read database/roles/readonly
 
 # Output
@@ -222,7 +222,7 @@ creation_statements  	CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GR
 db_name              	mysql
 default_ttl          	1800 #1800 seconds = 30 mins
 max_ttl              	86400 #<------------------------------------------------------------ #Note this value!!!
-renew_statements 
+renew_statements
 revocation_statements
 rollback_statements
 
@@ -230,6 +230,5 @@ rollback_statements
 ```
 
 ## Additional References:
-A complete guide for token and leases (including periodic tokens) can be found here:
-https://www.vaultproject.io/guides/identity/lease.html
-
+A complete guide for token (including periodic tokens) can be found here:
+https://learn.hashicorp.com/vault/identity-access-management/tokens

--- a/operations/provision-vault/README.md
+++ b/operations/provision-vault/README.md
@@ -72,4 +72,4 @@ $ cd operations/provision-vault/best-practices/terraform-aws
 
 ## Next Steps
 
-Now that you've provisioned and configured Vault, start walking through the [Vault Guides](https://www.vaultproject.io/guides/index.html).
+Now that you've provisioned and configured a best practices Vault & Consul cluster, visit our [learn](https://learn.hashicorp.com/vault/?track=secrets-management#secrets-managemen) site.

--- a/operations/provision-vault/best-practices/terraform-aws/README.md
+++ b/operations/provision-vault/best-practices/terraform-aws/README.md
@@ -8,7 +8,7 @@ The goal of this guide is to allows users to easily provision a best practices V
 - [Terraform Docs](https://www.terraform.io/docs/index.html)
 - [Consul Getting Started](https://www.consul.io/intro/getting-started/install.html)
 - [Consul Docs](https://www.consul.io/docs/index.html)
-- [Vault Getting Started](https://www.vaultproject.io/intro/getting-started/install.html)
+- [Vault Getting Started](https://learn.hashicorp.com/vault/getting-started/install)
 - [Vault Docs](https://www.vaultproject.io/docs/index.html)
 
 ## Estimated Time to Complete
@@ -89,4 +89,4 @@ $ terraform apply
 
 ## Next Steps
 
-Now that you've provisioned and configured a best practices Vault & Consul cluster, start walking through the [Vault Guides](https://www.vaultproject.io/guides/index.html).
+Now that you've provisioned and configured a best practices Vault & Consul cluster, visit our [learn](https://learn.hashicorp.com/vault/?track=secrets-management#secrets-managemen) site.

--- a/operations/provision-vault/dev/terraform-aws/README.md
+++ b/operations/provision-vault/dev/terraform-aws/README.md
@@ -87,4 +87,4 @@ $ terraform apply
 
 ## Next Steps
 
-Now that you've provisioned and configured a development Vault cluster, start walking through the [Vault Guides](https://www.vaultproject.io/guides/)
+Now that you've provisioned and configured a best practices Vault & Consul cluster, visit our [learn](https://learn.hashicorp.com/vault/?track=secrets-management#secrets-managemen) site.

--- a/operations/provision-vault/dev/vagrant-local/README.md
+++ b/operations/provision-vault/dev/vagrant-local/README.md
@@ -52,4 +52,4 @@ $ vagrant up
 
 ## Next Steps
 
-Now that you've provisioned and configured a development Vault cluster, start walking through the [Vault Guides](https://www.vaultproject.io/guides/)
+Now that you've provisioned and configured a best practices Vault & Consul cluster, visit our [learn](https://learn.hashicorp.com/vault/?track=secrets-management#secrets-managemen) site.

--- a/operations/provision-vault/quick-start/terraform-aws/README.md
+++ b/operations/provision-vault/quick-start/terraform-aws/README.md
@@ -89,4 +89,4 @@ $ terraform apply
 
 ## Next Steps
 
-Now that you've provisioned and configured a quick start Vault & Consul cluster, start walking through the [Vault Guides](https://www.vaultproject.io/guides/index.html).
+Now that you've provisioned and configured a best practices Vault & Consul cluster, visit our [learn](https://learn.hashicorp.com/vault/?track=secrets-management#secrets-managemen) site.

--- a/secrets/spring-cloud-vault/README.md
+++ b/secrets/spring-cloud-vault/README.md
@@ -13,7 +13,7 @@ webinar.
 
 ## Demo Instruction
 
-To keep it simple and lightweight, the [Java Sample App using Spring Cloud Vault](https://www.vaultproject.io/guides/encryption/spring-demo.html) guide used **Vagrant** to demonstrate the app.  This repository also provides example deployments on various platforms:
+To keep it simple and lightweight, the [Java Sample App using Spring Cloud Vault](https://learn.hashicorp.com/vault/developer/eaas-spring-demo) guide used **Vagrant** to demonstrate the app.  This repository also provides example deployments on various platforms:
 
 - [Nomad](nomad)
 - [Kubernetes](kubernetes)

--- a/secrets/spring-cloud-vault/vagrant-local/README.md
+++ b/secrets/spring-cloud-vault/vagrant-local/README.md
@@ -1,6 +1,6 @@
 # Java Sample App using Spring Cloud Vault (Vagrant)
 
-Refer to the [Java Sample App using Spring Cloud Vault](https://www.vaultproject.io/guides/encryption/spring-demo.html) guide for step-by-step instruction.
+Refer to the [Java Sample App using Spring Cloud Vault](https://learn.hashicorp.com/vault/developer/eaas-spring-demo) guide for step-by-step instruction.
 
 ----
 


### PR DESCRIPTION
Updated READMEs:
`https://www.vaultproject.io/guides` --> `https://learn.hashicorp.com/vault/`