### PR TITLE
Update variable references and os_profile/custom_data on azure unseal example

### DIFF
--- a/operations/azure-keyvault-unseal/main.tf
+++ b/operations/azure-keyvault-unseal/main.tf
@@ -3,10 +3,10 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "vault" {
   name     = "${var.environment}-vault-rg"
-  location = var.location
+  location = "${var.location}"
 
   tags = {
-    environment = var.environment
+    environment = "${var.environment}"
   }
 }
 
@@ -19,25 +19,25 @@ data "azurerm_client_config" "current" {
 
 resource "azurerm_key_vault" "vault" {
   name                        = "${var.environment}-vault-${random_id.keyvault.hex}"
-  location                    = azurerm_resource_group.vault.location
-  resource_group_name         = azurerm_resource_group.vault.name
+  location                    = "${azurerm_resource_group.vault.location}"
+  resource_group_name         = "${azurerm_resource_group.vault.name}"
   enabled_for_deployment      = true
   enabled_for_disk_encryption = true
-  tenant_id                   = var.tenant_id
+  tenant_id                   = "${var.tenant_id}"
 
   sku {
     name = "standard"
   }
 
   tags = {
-    environment = var.environment
+    environment = "${var.environment}"
   }
 
   access_policy {
-    tenant_id = var.tenant_id
+    tenant_id = "${var.tenant_id}"
 
     #object_id = "${var.object_id}"
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
 
     key_permissions = [
       "get",
@@ -57,8 +57,8 @@ resource "azurerm_key_vault" "vault" {
 }
 
 resource "azurerm_key_vault_key" "generated" {
-  name         = var.key_name
-  key_vault_id = azurerm_key_vault.vault.id
+  name         = "${var.key_name}"
+  key_vault_id = "${azurerm_key_vault.vault.id}"
   key_type     = "RSA"
   key_size     = 2048
 
@@ -73,7 +73,7 @@ resource "azurerm_key_vault_key" "generated" {
 }
 
 output "key_vault_name" {
-  value = azurerm_key_vault.vault.name
+  value = "${azurerm_key_vault.vault.name}"
 }
 
 # ---------------------
@@ -82,8 +82,8 @@ output "key_vault_name" {
 resource "azurerm_virtual_network" "tf_network" {
   name                = "network-${random_id.keyvault.hex}"
   address_space       = ["10.0.0.0/16"]
-  location            = var.location
-  resource_group_name = azurerm_resource_group.vault.name
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.vault.name}"
 
   tags = {
     environment = "${var.environment}-${random_id.keyvault.hex}"
@@ -92,15 +92,15 @@ resource "azurerm_virtual_network" "tf_network" {
 
 resource "azurerm_subnet" "tf_subnet" {
   name                 = "subnet-${random_id.keyvault.hex}"
-  resource_group_name  = azurerm_resource_group.vault.name
-  virtual_network_name = azurerm_virtual_network.tf_network.name
+  resource_group_name  = "${azurerm_resource_group.vault.name}"
+  virtual_network_name = "${azurerm_virtual_network.tf_network.name}"
   address_prefix       = "10.0.1.0/24"
 }
 
 resource "azurerm_public_ip" "tf_publicip" {
   name                = "ip-${random_id.keyvault.hex}"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.vault.name
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.vault.name}"
   allocation_method   = "Dynamic"
 
   tags = {
@@ -110,8 +110,8 @@ resource "azurerm_public_ip" "tf_publicip" {
 
 resource "azurerm_network_security_group" "tf_nsg" {
   name                = "nsg-${random_id.keyvault.hex}"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.vault.name
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.vault.name}"
 
   security_rule {
     name                       = "SSH"
@@ -156,15 +156,15 @@ resource "azurerm_network_security_group" "tf_nsg" {
 
 resource "azurerm_network_interface" "tf_nic" {
   name                      = "nic-${random_id.keyvault.hex}"
-  location                  = var.location
-  resource_group_name       = azurerm_resource_group.vault.name
-  network_security_group_id = azurerm_network_security_group.tf_nsg.id
+  location                  = "${var.location}"
+  resource_group_name       = "${azurerm_resource_group.vault.name}"
+  network_security_group_id = "${azurerm_network_security_group.tf_nsg.id}"
 
   ip_configuration {
     name                          = "nic-${random_id.keyvault.hex}"
-    subnet_id                     = azurerm_subnet.tf_subnet.id
+    subnet_id                     = "${azurerm_subnet.tf_subnet.id}"
     private_ip_address_allocation = "dynamic"
-    public_ip_address_id          = azurerm_public_ip.tf_publicip.id
+    public_ip_address_id          = "${azurerm_public_ip.tf_publicip.id}"
   }
 
   tags = {
@@ -175,7 +175,7 @@ resource "azurerm_network_interface" "tf_nic" {
 resource "random_id" "tf_random_id" {
   keepers = {
     # Generate a new ID only when a new resource group is defined
-    resource_group = azurerm_resource_group.vault.name
+    resource_group = "${azurerm_resource_group.vault.name}"
   }
 
   byte_length = 8
@@ -183,8 +183,8 @@ resource "random_id" "tf_random_id" {
 
 resource "azurerm_storage_account" "tf_storageaccount" {
   name                     = "sa${random_id.keyvault.hex}"
-  resource_group_name      = azurerm_resource_group.vault.name
-  location                 = var.location
+  resource_group_name      = "${azurerm_resource_group.vault.name}"
+  location                 = "${var.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
@@ -194,27 +194,27 @@ resource "azurerm_storage_account" "tf_storageaccount" {
 }
 
 data "template_file" "setup" {
-  template = file("${path.module}/setup.tpl")
+  template = "${file("${path.module}/setup.tpl")}"
 
   vars = {
     resource_group_name = "${var.environment}-vault-rg"
-    vm_name             = var.vm_name
-    vault_download_url  = var.vault_download_url
-    tenant_id           = var.tenant_id
-    subscription_id     = var.subscription_id
-    client_id           = var.client_id
-    client_secret       = var.client_secret
-    vault_name          = azurerm_key_vault.vault.name
-    key_name            = var.key_name
+    vm_name             = "${var.vm_name}"
+    vault_download_url  = "${var.vault_download_url}"
+    tenant_id           = "${var.tenant_id}"
+    subscription_id     = "${var.subscription_id}"
+    client_id           = "${var.client_id}"
+    client_secret       = "${var.client_secret}"
+    vault_name          = "${azurerm_key_vault.vault.name}"
+    key_name            = "${var.key_name}"
   }
 }
 
 # Create virtual machine
 resource "azurerm_virtual_machine" "tf_vm" {
-  name                  = var.vm_name
-  location              = var.location
-  resource_group_name   = azurerm_resource_group.vault.name
-  network_interface_ids = [azurerm_network_interface.tf_nic.id]
+  name                  = "${var.vm_name}"
+  location              = "${var.location}"
+  resource_group_name   = "${azurerm_resource_group.vault.name}"
+  network_interface_ids = ["${azurerm_network_interface.tf_nic.id}"]
   vm_size               = "Standard_DS1_v2"
 
   identity {
@@ -236,22 +236,22 @@ resource "azurerm_virtual_machine" "tf_vm" {
   }
 
   os_profile {
-    computer_name  = var.vm_name
+    computer_name  = "${var.vm_name}"
     admin_username = "azureuser"
-    custom_data    = data.template_file.setup.rendered
+    custom_data    = "${base64encode("${data.template_file.setup.rendered}")}"
   }
 
   os_profile_linux_config {
     disable_password_authentication = true
     ssh_keys {
       path     = "/home/azureuser/.ssh/authorized_keys"
-      key_data = var.public_key
+      key_data = "${var.public_key}"
     }
   }
 
   boot_diagnostics {
     enabled     = "true"
-    storage_uri = azurerm_storage_account.tf_storageaccount.primary_blob_endpoint
+    storage_uri = "${azurerm_storage_account.tf_storageaccount.primary_blob_endpoint}"
   }
 
   tags = {
@@ -260,12 +260,12 @@ resource "azurerm_virtual_machine" "tf_vm" {
 }
 
 data "azurerm_public_ip" "tf_publicip" {
-  name                = azurerm_public_ip.tf_publicip.name
-  resource_group_name = azurerm_virtual_machine.tf_vm.resource_group_name
+  name                = "${azurerm_public_ip.tf_publicip.name}"
+  resource_group_name = "${azurerm_virtual_machine.tf_vm.resource_group_name}"
 }
 
 output "ip" {
-  value = data.azurerm_public_ip.tf_publicip.ip_address
+  value = "${data.azurerm_public_ip.tf_publicip.ip_address}"
 }
 
 output "ssh-addr" {


### PR DESCRIPTION
Following the guide and noticed a few things so these are the proposed updates

- Updating variable references to have double quotes which make it more friendly to VS code
- Adding `base64encode `function on the `custom_data` of `os_profile` property on `tf_vm` resource under Azure unseal sample. Without this function, it seems the custom_data does not get applied. This may be related to Custom Data property in the following Azure document, please have a review. https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.fluent.models.osprofile.customdata?view=azure-dotnet