### PR TITLE
Aws kms unseal ha terraform fix

### DIFF
--- a/operations/aws-kms-unseal-ha/terraform/README.md
+++ b/operations/aws-kms-unseal-ha/terraform/README.md
@@ -3,21 +3,19 @@
 In this guide, we'll show an example of how to use Terraform to provision a cluster that can utilize an encryption key from AWS Key Management Services to unseal Vault.
 
 ## Overview
-Vault unseal operation either requires either a number of people who each possess a shard of a key, split by Shamir's Secret sharing algorithm, or protection of the master key via an HSM or cloud key management services (Google CKMS or AWS KMS). 
+Vault unseal operation either requires either a number of people who each possess a shard of a key, split by Shamir's Secret sharing algorithm, or protection of the master key via an HSM or cloud key management services (Google CKMS or AWS KMS).
 
-This guide has a guide on how to implement and use this feature in AWS. Included is a Terraform configuration that has the following features:  
-* Ubuntu 16.04 LTS with Vault Enterprise (0.9.0+prem.hsm).   
-* An instance profile granting the AWS EC2 instance to a KMS key.   
-* Vault configured with access to a KMS key.   
+This guide has a guide on how to implement and use this feature in AWS. Included is a Terraform configuration that has the following features:
+* Ubuntu 16.04 LTS with Vault
+* An instance profile granting the AWS EC2 instance to a KMS key.
+* Vault configured with access to a KMS key.
 
 
 ## Prerequisites
 
-This guide assumes the following:   
+This guide assumes the following:
 
-1. Access to Vault Enterprise > 0.9.0 which supports AWS KMS as an unseal mechanism. 
-1. A URL to download Vault Enterprise from (an S3 bucket will suffice). 
-1. AWS account for provisioning cloud resources. 
+1. AWS account for provisioning cloud resources.
 1. Terraform installed, and basic understanding of its usage
 
 
@@ -27,15 +25,19 @@ Instructions assume this location as a working directory, as well as AWS credent
 1. Set Vault Enterprise URL in a file named terraform.tfvars (see terraform.tfvars.example)
 1. Perform the following to provision the environment
 
-```
-terraform init
-terraform plan
-terraform apply
+```bash
+# Pull necessary plugins
+$ terraform init
+
+$ terraform plan
+
+# Output provides the SSH instruction
+$ terraform apply
 ```
 
 Outputs will contain instructions to connect to the server via SSH
 
-```
+```bash
 Apply complete! Resources: 17 added, 0 changed, 0 destroyed.
 
 Outputs:
@@ -52,52 +54,23 @@ Vault Enterprise web interface  http://34.200.221.65:8200/ui```
 
 Login to one of the instances
 
-```
-# vault status
-Error checking seal status: Error making API request.
-
-URL: GET http://127.0.0.1:8200/v1/sys/seal-status
-Code: 400. Errors:
-
-* server is not yet initialized
-
-# Active a primary node
-# vault init -stored-shares=1 -recovery-shares=1 -recovery-threshold=1 -key-shares=1 -key-threshold=1
-Recovery Key 1: oOxAQfxcZitjqZfF3984De8rUckPeahQDUvmJ1A4JrQ=
-Initial Root Token: 54c4dbe3-d45b-79d9-18d0-602831a6a991
-
-Vault initialized successfully.
-
-Recovery key initialized with 1 keys and a key threshold of 1. Please
-securely distribute the above keys.
-
-# systemctl stop vault
-root@ip-192-168-100-100:~# vault status
-Error checking seal status: Get http://127.0.0.1:8200/v1/sys/seal-status: dial tcp 127.0.0.1:8200: getsockopt: connection refused
-
-# systemctl start vault
+```bash
 $ vault status
-Key                      Value
----                      -----
-Recovery Seal Type       shamir
-Sealed                   false
-Total Recovery Shares    1
-Threshold                1
-Version                  0.9.4+ent
-Cluster Name             vault-cluster-17200d37
-Cluster ID               81c09b45-0ff3-a1c6-65c6-4df2964b261e
-HA Enabled               true
-HA Cluster               https://192.168.100.166:8201
-HA Mode                  standby
-Active Node Address:     http://192.168.100.166:82001
 
-High-Availability Enabled: false
+# Initialize Vault
+$ vault operator init -recovery-shares=1 -recovery-threshold=1
 
-# vault auth 54c4dbe3-d45b-79d9-18d0-602831a6a991
-Successfully authenticated! You are now logged in.
-token: 54c4dbe3-d45b-79d9-18d0-602831a6a991
-token_duration: 0
-token_policies: [root]
+# The current machine is the Active node
+$ vault status
+
+# Restart the Vault server
+$ sudo systemctl restart vault
+
+# Check to verify that the Vault is auto-unsealed
+# and that another node is now Active
+$ vault status
+
+$ vault login <INITIAL_ROOT_TOKEN>
 
 
 # cat /etc/vault.d/vault.hcl
@@ -116,7 +89,7 @@ ui=true
 
 Login to a different node and check the status of Vault (One of them should now be active)
 
-```
+```bash
 $ vault status
 Key                      Value
 ---                      -----
@@ -137,7 +110,6 @@ Once complete perform the following to clean up
 ```
 terraform destroy -force
 rm -rf .terraform terraform.tfstate* private.key
-
 ```
 
 

--- a/operations/aws-kms-unseal-ha/terraform/instance-profile.tf
+++ b/operations/aws-kms-unseal-ha/terraform/instance-profile.tf
@@ -20,23 +20,23 @@ data "aws_iam_policy_document" "vault-kms-unseal" {
       "kms:Encrypt",
       "kms:Decrypt",
       "kms:DescribeKey",
-      "ec2:DescribeInstances"
+      "ec2:DescribeInstances",
     ]
   }
 }
 
 resource "aws_iam_role" "vault-kms-unseal" {
   name               = "vault-kms-role-${random_pet.env.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "vault-kms-unseal" {
   name   = "Vault-KMS-Unseal-${random_pet.env.id}"
-  role   = "${aws_iam_role.vault-kms-unseal.id}"
-  policy = "${data.aws_iam_policy_document.vault-kms-unseal.json}"
+  role   = aws_iam_role.vault-kms-unseal.id
+  policy = data.aws_iam_policy_document.vault-kms-unseal.json
 }
 
 resource "aws_iam_instance_profile" "vault-kms-unseal" {
   name = "vault-kms-unseal-${random_pet.env.id}"
-  role = "${aws_iam_role.vault-kms-unseal.name}"
+  role = aws_iam_role.vault-kms-unseal.name
 }

--- a/operations/aws-kms-unseal-ha/terraform/instance.tf
+++ b/operations/aws-kms-unseal-ha/terraform/instance.tf
@@ -2,7 +2,7 @@ resource "aws_kms_key" "vault" {
   description             = "Vault unseal key"
   deletion_window_in_days = 10
 
-  tags {
+  tags = {
     Name = "vault-kms-unseal-${random_pet.env.id}"
   }
 }
@@ -23,36 +23,36 @@ data "aws_ami" "ubuntu" {
 }
 
 resource "aws_instance" "vault" {
-  ami           = "${data.aws_ami.ubuntu.id}"
+  ami           = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
   count         = 3
-  subnet_id     = "${aws_subnet.public_subnet.id}"
+  subnet_id     = aws_subnet.public_subnet.id
   key_name      = "vault-kms-unseal-${random_pet.env.id}"
 
   security_groups = [
-    "${aws_security_group.vault.id}",
+    aws_security_group.vault.id,
   ]
 
   associate_public_ip_address = true
   ebs_optimized               = false
-  iam_instance_profile        = "${aws_iam_instance_profile.vault-kms-unseal.id}"
+  iam_instance_profile        = aws_iam_instance_profile.vault-kms-unseal.id
 
-  tags {
-    Name = "Vault_KMS_unseal_cluster"
+  tags = {
+    Name             = "Vault_KMS_unseal_cluster"
     environment_name = "vault-kms-unseal-${random_pet.env.id}"
   }
 
-  user_data = "${data.template_file.vault.rendered}"
+  user_data = data.template_file.vault.rendered
 }
 
 data "template_file" "vault" {
-  template = "${file("userdata.tpl")}"
+  template = file("userdata.tpl")
 
   vars = {
-    kms_key    = "${aws_kms_key.vault.id}"
-    vault_url  = "${var.vault_url}"
-    aws_region = "${var.aws_region}"
-    cluster_size = "3"
+    kms_key          = aws_kms_key.vault.id
+    vault_url        = var.vault_url
+    aws_region       = var.aws_region
+    cluster_size     = "3"
     environment_name = "vault-kms-unseal-${random_pet.env.id}"
   }
 }
@@ -60,125 +60,126 @@ data "template_file" "vault" {
 data "template_file" "format_ssh" {
   template = "connect to host with following command: ssh ubuntu@$${admin} -i private.key"
 
-  vars {
-    admin = "${aws_instance.vault.0.public_ip}"
+  vars = {
+    admin = aws_instance.vault[0].public_ip
   }
 }
 
 output "connections" {
   value = <<VAULT
-Connect to Node1 via SSH   ssh ubuntu@${aws_instance.vault.0.public_ip} -i private.key
-Vault Enterprise web interface  http://${aws_instance.vault.0.public_ip}:8200/ui
+Connect to Node1 via SSH   ssh ubuntu@${aws_instance.vault[0].public_ip} -i private.key
+Vault Enterprise web interface  http://${aws_instance.vault[0].public_ip}:8200/ui
 
-Connect to Node2 via SSH   ssh ubuntu@${aws_instance.vault.1.public_ip} -i private.key
-Vault Enterprise web interface  http://${aws_instance.vault.1.public_ip}:8200/ui
+Connect to Node2 via SSH   ssh ubuntu@${aws_instance.vault[1].public_ip} -i private.key
+Vault Enterprise web interface  http://${aws_instance.vault[1].public_ip}:8200/ui
 
-Connect to Node3 via SSH   ssh ubuntu@${aws_instance.vault.2.public_ip} -i private.key
-Vault Enterprise web interface  http://${aws_instance.vault.2.public_ip}:8200/ui
+Connect to Node3 via SSH   ssh ubuntu@${aws_instance.vault[2].public_ip} -i private.key
+Vault Enterprise web interface  http://${aws_instance.vault[2].public_ip}:8200/ui
 VAULT
+
 }
 
 resource "aws_security_group" "vault" {
-  name        = "vault-kms-unseal-${random_pet.env.id}"
+  name = "vault-kms-unseal-${random_pet.env.id}"
   description = "vault access"
-  vpc_id      = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 
-  tags {
+  tags = {
     Name = "vault-kms-unseal-${random_pet.env.id}"
   }
 
   # SSH
   ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # Vault Client Traffic
   ingress {
-    from_port   = 8200
-    to_port     = 8201
-    protocol    = "tcp"
+    from_port = 8200
+    to_port = 8201
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-    # DNS (TCP)
+  # DNS (TCP)
   ingress {
-    from_port   = 8600
-    to_port     = 8600
-    protocol    = "tcp"
+    from_port = 8600
+    to_port = 8600
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # DNS (UDP)
   ingress {
-    from_port   = 8600
-    to_port     = 8600
-    protocol    = "udp"
+    from_port = 8600
+    to_port = 8600
+    protocol = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # HTTP Consul
   ingress {
-    from_port   = 8500
-    to_port     = 8500
-    protocol    = "tcp"
+    from_port = 8500
+    to_port = 8500
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # Serf LAN (TCP)
   ingress {
-    from_port   = 8301
-    to_port     = 8301
-    protocol    = "tcp"
+    from_port = 8301
+    to_port = 8301
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # Serf LAN (UDP)
   ingress {
-    from_port   = 8301
-    to_port     = 8301
-    protocol    = "udp"
+    from_port = 8301
+    to_port = 8301
+    protocol = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-    # Serf WAN (TCP)
+  # Serf WAN (TCP)
   ingress {
-    from_port   = 8302
-    to_port     = 8302
-    protocol    = "tcp"
+    from_port = 8302
+    to_port = 8302
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # Serf WAN (UDP)
   ingress {
-    from_port   = 8302
-    to_port     = 8302
-    protocol    = "udp"
+    from_port = 8302
+    to_port = 8302
+    protocol = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # Consul Server RPC
   ingress {
-    from_port   = 8300
-    to_port     = 8300
-    protocol    = "tcp"
+    from_port = 8300
+    to_port = 8300
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   # RPC Consul
   ingress {
-    from_port   = 8400
-    to_port     = 8400
-    protocol    = "tcp"
+    from_port = 8400
+    to_port = 8400
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/operations/aws-kms-unseal-ha/terraform/main.tf
+++ b/operations/aws-kms-unseal-ha/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 resource "random_pet" "env" {
@@ -8,47 +8,47 @@ resource "random_pet" "env" {
 }
 
 resource "aws_vpc" "vpc" {
-  cidr_block           = "${var.vpc_cidr}"
+  cidr_block           = var.vpc_cidr
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "vault-kms-unseal-${random_pet.env.id}"
   }
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 
-  tags {
+  tags = {
     Name = "vault-kms-unseal-${random_pet.env.id}"
   }
 }
 
 resource "aws_subnet" "public_subnet" {
-  vpc_id                  = "${aws_vpc.vpc.id}"
-  cidr_block              = "${var.vpc_cidr}"
-  availability_zone       = "${var.aws_zone}"
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.vpc_cidr
+  availability_zone       = var.aws_zone
   map_public_ip_on_launch = true
 
-  tags {
+  tags = {
     Name = "vault-kms-unseal-${random_pet.env.id}"
   }
 }
 
 resource "aws_route_table" "route" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gw.id}"
+    gateway_id = aws_internet_gateway.gw.id
   }
 
-  tags {
+  tags = {
     Name = "vault-kms-unseal-${random_pet.env.id}"
   }
 }
 
 resource "aws_route_table_association" "route" {
-  subnet_id      = "${aws_subnet.public_subnet.id}"
-  route_table_id = "${aws_route_table.route.id}"
+  subnet_id      = aws_subnet.public_subnet.id
+  route_table_id = aws_route_table.route.id
 }

--- a/operations/aws-kms-unseal-ha/terraform/ssh-key.tf
+++ b/operations/aws-kms-unseal-ha/terraform/ssh-key.tf
@@ -14,5 +14,5 @@ resource "null_resource" "main" {
 
 resource "aws_key_pair" "main" {
   key_name   = "vault-kms-unseal-${random_pet.env.id}"
-  public_key = "${tls_private_key.main.public_key_openssh}"
+  public_key = tls_private_key.main.public_key_openssh
 }

--- a/operations/aws-kms-unseal-ha/terraform/terraform.tfvars.example
+++ b/operations/aws-kms-unseal-ha/terraform/terraform.tfvars.example
@@ -1,1 +1,5 @@
-vault_url = "http://s3.amazonaws.com/some/path/to/vault-enterprise.zip"
+#------------------------------------------------
+# Modify the region to use different AWS region
+#------------------------------------------------
+aws_region = "eu-west-1"
+aws_zone = "eu-west-1a"

--- a/operations/aws-kms-unseal-ha/terraform/variables.tf
+++ b/operations/aws-kms-unseal-ha/terraform/variables.tf
@@ -14,4 +14,5 @@ variable "vpc_cidr" {
 
 variable "vault_url" {
   description = "URL to download Vault Enterprise"
+  default     = "https://releases.hashicorp.com/vault/1.1.2/vault_1.1.2_linux_amd64.zip"
 }

--- a/operations/aws-kms-unseal-ha/terraform/variables.tf
+++ b/operations/aws-kms-unseal-ha/terraform/variables.tf
@@ -1,18 +1,17 @@
-variable aws_region {
+variable "aws_region" {
   default = "us-east-1"
 }
 
-variable aws_zone {
+variable "aws_zone" {
   default = "us-east-1a"
 }
 
-variable vpc_cidr {
-  type        = "string"
+variable "vpc_cidr" {
+  type        = string
   description = "CIDR of the VPC"
   default     = "192.168.100.0/24"
 }
 
-variable vault_url {
+variable "vault_url" {
   description = "URL to download Vault Enterprise"
 }
-

--- a/operations/aws-kms-unseal-ha/terraform/versions.tf
+++ b/operations/aws-kms-unseal-ha/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
* Updates to terraform 0.12 syntax,
* Use opensource version of Vault as KMS is not an enterprise feature any more
* Updates the `readme.md` to have valid Vault CLI commands, and closer match the `aws-kms-unseal` guide