### PR TITLE
readme updates, added consul qty. authenticate.lua

### DIFF
--- a/operations/benchmarking/terraform-aws-vault-benchmark/terraform/consul.tf
+++ b/operations/benchmarking/terraform-aws-vault-benchmark/terraform/consul.tf
@@ -10,10 +10,10 @@ data "aws_ami" "consul" {
 }
 
 resource "aws_instance" "consul" {
-  count             = 3
+  count             = "${var.consul_cluster_size}"
   ami               = "${data.aws_ami.consul.id}"
   instance_type     = "m5.4xlarge"
-  subnet_id         = "${module.vpc.private_subnets[count.index]}"
+  subnet_id         = "${element(module.vpc.private_subnets, count.index)}"
   key_name          = "${aws_key_pair.aws.key_name}"
   associate_public_ip_address = false
   ebs_optimized     = "true"

--- a/operations/benchmarking/terraform-aws-vault-benchmark/terraform/variables.tf
+++ b/operations/benchmarking/terraform-aws-vault-benchmark/terraform/variables.tf
@@ -8,6 +8,9 @@ variable "region" {}
 variable "consul_ami" {}
 variable "vault_ami" {}
 
+variable "consul_cluster_size" {
+    default = "3"
+}
 
 variable "vault_ips" {
     default = {

--- a/operations/benchmarking/wrk-core-vault-operations/authenticate.lua
+++ b/operations/benchmarking/wrk-core-vault-operations/authenticate.lua
@@ -1,0 +1,56 @@
+-- Script that authenticates a user against Vault's userpass system.
+-- This script should be used with batch tokens only. Any Leases (if issued) are not revoked.
+
+local counter = 1
+local threads = {}
+
+function setup(thread)
+   thread:set("id", counter)
+   table.insert(threads, thread)
+   counter = counter + 1
+end
+
+function init(args)
+   requests  = 0
+   authentications = 0
+   revocations = 0
+   responses = 0
+   local msg = "thread %d created"
+   print(msg:format(id))
+end
+
+function request()
+   requests = requests + 1
+
+   -- Authenticate
+   authentications = authentications + 1
+   method = "POST"
+   path = "/v1/auth/userpass/login/loadtester"
+   body = '{"password" : "benchmark" }'
+   -- print("Authenticating")
+
+return wrk.format(method, path, nil, body)
+end
+
+function delay()
+   return 0
+end
+
+function response(status, headers, body)
+   if status == 200  or status == 204 then
+      responses = responses + 1
+   end
+   -- print("Status: " .. status)
+end
+
+function done(summary, latency, requests)
+   for index, thread in ipairs(threads) do
+      local id        = thread:get("id")
+      local requests  = thread:get("requests")
+      local authentications    = thread:get("authentications")
+      local revocations    = thread:get("revocations")
+      local responses = thread:get("responses")
+      local msg = "thread %d made %d authentications and %d revocations and got %d responses"
+      print(msg:format(id, authentications, revocations, responses))
+   end
+end


### PR DESCRIPTION
- Added a `authenticate.lua` script and readme instructions to test batch tokens
- Added variable to allow creating a higher qty. of consul servers than 3 (defaults to 3). This is for testing consul with non-voting members in enterprise redundancy zones.