### PR TITLE
Refresh the GCP GCE Example code:

### DIFF
--- a/identity/gcp-gce-auth/README.md
+++ b/identity/gcp-gce-auth/README.md
@@ -20,7 +20,7 @@ The project will create the following resources in GCP:
 * Vault-sad - A GCE instance not in the bound region - This should not be able to get a token from Vault
 * vault-auth-checker - A Service Account with the Compute Viewer and Security Viewer permissions - Vault will use these credentials for the GCE backend
 
-Note: These resources will be access bound to the IP of the machine running Terraform.
+Note: These resources will be firewall access bound to the IP of the machine running Terraform.
 
 We will then create the following Vault install and configuration using the vault-server:
 
@@ -121,10 +121,10 @@ vault_addr_export = Run the following for the Vault configuration: export VAULT_
 
 Initialize Vault:
 ```
-vault operator init
+vault operator init -key-shares=1 -key-threshold=1
 ```
 
-Unseal Vault (by supplying at least 3 keys from the above output)
+Unseal Vault (by supplying at least a key from the above output)
 ```
 vault operator unseal
 Unseal Key (will be hidden): <Enter key here>
@@ -140,7 +140,6 @@ export VAULT_TOKEN=s.KkNJYWF5g0pomcCLEmDdOVCW
 Configure Vault with Terraform code:
 ```
 cd vault/
-vault auth enable gcp
 terraform plan
 terraform apply
 cd ..

--- a/identity/gcp-gce-auth/compute.tf
+++ b/identity/gcp-gce-auth/compute.tf
@@ -2,41 +2,42 @@ data "http" "current_ip" {
   url = "http://ipv4.icanhazip.com/"
 }
 
-data "template_file" "requester_bootstrap" {
-  template = "${file("${path.module}/templates/requester.sh.tpl")}"
-
-  vars {
-    vault_addr = "http://${google_compute_instance.vault_server.network_interface.0.access_config.0.assigned_nat_ip}:8200"
-  }
+locals {
+  bootstrap_script = templatefile(
+    "${path.module}/templates/requester.sh.tpl",
+    {
+      vault_addr = "http://${google_compute_instance.vault_server.network_interface[0].access_config[0].nat_ip}:8200"
+    },
+  )
 }
 
 resource "google_compute_network" "vault_gcp_demo_network" {
-  project    = "${google_project.vault_gcp_demo.project_id}"
+  project    = google_project.vault_gcp_demo.project_id
   name       = "vault-gcp-demo"
-  depends_on = ["google_project_services.vault_gcp_demo_services"]
+  depends_on = [google_project_services.vault_gcp_demo_services]
 }
 
 resource "google_compute_firewall" "allow_vault_access" {
-  project    = "${google_project.vault_gcp_demo.project_id}"
+  project    = google_project.vault_gcp_demo.project_id
   name       = "allow-vault-access"
-  network    = "${google_compute_network.vault_gcp_demo_network.self_link}"
-  depends_on = ["google_project_services.vault_gcp_demo_services"]
-
+  network    = google_compute_network.vault_gcp_demo_network.self_link
+  depends_on = [
+    google_project_services.vault_gcp_demo_services,
+    google_compute_instance.vault_happy,
+    google_compute_instance.vault_sad,
+  ]
   allow {
     protocol = "icmp"
   }
-
   allow {
     protocol = "tcp"
     ports    = ["22", "8200"]
   }
-
   source_ranges = [
     "${chomp(data.http.current_ip.body)}/32",
-    "${google_compute_instance.vault_happy.network_interface.0.access_config.0.assigned_nat_ip}/32",
-    "${google_compute_instance.vault_sad.network_interface.0.access_config.0.assigned_nat_ip}/32",
+    "${google_compute_instance.vault_happy.network_interface[0].access_config[0].nat_ip}/32",
+    "${google_compute_instance.vault_sad.network_interface[0].access_config[0].nat_ip}/32",
   ]
-
   target_tags = ["vault-server", "vault-requester"]
 }
 
@@ -44,33 +45,23 @@ resource "google_compute_instance" "vault_server" {
   name         = "vault-server"
   machine_type = "n1-standard-1"
   zone         = "europe-west2-a"
-  project      = "${google_project.vault_gcp_demo.project_id}"
+  project      = google_project.vault_gcp_demo.project_id
   tags         = ["vault-server"]
-  depends_on   = ["google_project_services.vault_gcp_demo_services"]
-
+  depends_on   = [google_project_services.vault_gcp_demo_services]
   network_interface {
-    network = "${google_compute_network.vault_gcp_demo_network.self_link}"
-
-    access_config {} # Public-facing IP
+    network = google_compute_network.vault_gcp_demo_network.self_link
+    access_config { # Public-facing IP
+    }
   }
-
   boot_disk {
     initialize_params {
       image = "debian-cloud/debian-9"
     }
   }
-
-  metadata_startup_script = "${file("./scripts/install_vault.sh")}"
-
+  metadata_startup_script = file("./scripts/install_vault.sh")
   service_account {
-    scopes = [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append",
-      "https://www.googleapis.com/auth/monitoring.write",
-    ]
+    email  = google_service_account.vault_auth_checker.email
+    scopes = ["cloud-platform"]
   }
 }
 
@@ -78,86 +69,59 @@ resource "google_compute_instance" "vault_happy" {
   name         = "vault-requester-happy"
   machine_type = "f1-micro"
   zone         = "europe-west2-a"
-  project      = "${google_project.vault_gcp_demo.project_id}"
+  project      = google_project.vault_gcp_demo.project_id
   tags         = ["vault-requester"]
-  depends_on   = ["google_project_services.vault_gcp_demo_services"]
-
+  depends_on   = [google_project_services.vault_gcp_demo_services]
   network_interface {
     network = "default"
-
     access_config {
       // Ephemeral IP
     }
   }
-
   boot_disk {
     initialize_params {
       image = "debian-cloud/debian-9"
     }
   }
-
-  metadata_startup_script = "${data.template_file.requester_bootstrap.rendered}"
-
+  metadata_startup_script = local.bootstrap_script
   service_account {
-    scopes = [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append",
-      "https://www.googleapis.com/auth/monitoring.write",
-    ]
+    email  = "${google_service_account.vault_auth_checker.email}"
+    scopes = ["cloud-platform"]
   }
 }
-
 resource "google_compute_instance" "vault_sad" {
   name         = "vault-requester-sad"
   machine_type = "f1-micro"
   zone         = "europe-west1-b"
-  project      = "${google_project.vault_gcp_demo.project_id}"
+  project      = google_project.vault_gcp_demo.project_id
   tags         = ["vault-requester"]
-  depends_on   = ["google_project_services.vault_gcp_demo_services"]
-
+  depends_on   = [google_project_services.vault_gcp_demo_services]
   network_interface {
     network = "default"
-
     access_config {
       // Ephemeral IP
     }
   }
-
   boot_disk {
     initialize_params {
       image = "debian-cloud/debian-9"
     }
   }
-
-  metadata_startup_script = "${data.template_file.requester_bootstrap.rendered}"
-
+  metadata_startup_script = local.bootstrap_script
   service_account {
-    scopes = [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append",
-      "https://www.googleapis.com/auth/monitoring.write",
-    ]
+    email  = "${google_service_account.vault_auth_checker.email}"
+    scopes = ["cloud-platform"]
   }
 }
-
 output "vault_server_instance_id" {
-  value = "${google_compute_instance.vault_server.self_link}"
+  value = google_compute_instance.vault_server.self_link
 }
-
 output "vault_happy_instance_id" {
-  value = "${google_compute_instance.vault_happy.self_link}"
+  value = google_compute_instance.vault_happy.self_link
 }
-
 output "vault_sad_instance_id" {
-  value = "${google_compute_instance.vault_sad.self_link}"
+  value = google_compute_instance.vault_sad.self_link
 }
-
 output "vault_addr_export" {
-  value = "Run the following for the Vault configuration: export VAULT_ADDR=http://${google_compute_instance.vault_server.network_interface.0.access_config.0.assigned_nat_ip}:8200"
+  value = "Run the following for the Vault configuration: export VAULT_ADDR=http://${google_compute_instance.vault_server.network_interface[0].access_config[0].nat_ip}:8200"
 }

--- a/identity/gcp-gce-auth/project.tf
+++ b/identity/gcp-gce-auth/project.tf
@@ -1,25 +1,30 @@
-variable "billing_account" {}
+locals {
+  server_read_roles = [
+    "roles/compute.viewer",
+    "roles/iam.securityReviewer",
+  ]
+}
 
-variable "org_id" {}
+variable "billing_account" {
+}
 
-provider "google" {
-  version = "1.16.2"
+variable "org_id" {
 }
 
 resource "random_id" "id" {
   byte_length = 4
-  prefix      = "vault-gcp-demo-"
+  prefix      = "vault-guides-gcp-demo-"
 }
 
 resource "google_project" "vault_gcp_demo" {
   name            = "vault-gcp-demo"
-  project_id      = "${random_id.id.hex}"
-  billing_account = "${var.billing_account}"
-  org_id          = "${var.org_id}"
+  project_id      = random_id.id.hex
+  billing_account = var.billing_account
+  org_id          = var.org_id
 }
 
 resource "google_project_services" "vault_gcp_demo_services" {
-  project = "${google_project.vault_gcp_demo.project_id}"
+  project = google_project.vault_gcp_demo.project_id
 
   services = [
     "oslogin.googleapis.com",
@@ -29,35 +34,19 @@ resource "google_project_services" "vault_gcp_demo_services" {
   ]
 }
 
-output "project_id" {
-  value = "${google_project.vault_gcp_demo.project_id}"
-}
-
 resource "google_service_account" "vault_auth_checker" {
-  project      = "${google_project.vault_gcp_demo.project_id}"
+  project      = google_project.vault_gcp_demo.project_id
   account_id   = "vault-auth-checker"
   display_name = "Vault Auth Checker"
 }
 
-resource "google_project_iam_policy" "vault_policy" {
-  project     = "${google_project.vault_gcp_demo.project_id}"
-  policy_data = "${data.google_iam_policy.vault_policy.policy_data}"
+resource "google_project_iam_member" "server_roles" {
+  count   = length(local.server_read_roles)
+  role    = local.server_read_roles[count.index]
+  project = google_project.vault_gcp_demo.project_id
+  member  = "serviceAccount:${google_service_account.vault_auth_checker.email}"
 }
 
-data "google_iam_policy" "vault_policy" {
-  binding {
-    role = "roles/compute.viewer"
-
-    members = [
-      "serviceAccount:${google_service_account.vault_auth_checker.email}",
-    ]
-  }
-
-  binding {
-    role = "roles/iam.securityReviewer"
-
-    members = [
-      "serviceAccount:${google_service_account.vault_auth_checker.email}",
-    ]
-  }
+output "project_id" {
+  value = google_project.vault_gcp_demo.project_id
 }

--- a/identity/gcp-gce-auth/service_account.tf
+++ b/identity/gcp-gce-auth/service_account.tf
@@ -1,9 +1,0 @@
-resource "google_service_account_key" "vault_auth_checker_credentials" {
-  service_account_id = "${google_service_account.vault_auth_checker.name}"
-  public_key_type    = "TYPE_X509_PEM_FILE"
-}
-
-resource "local_file" "vault_service_account_cred_file" {
-  content  = "${base64decode(google_service_account_key.vault_auth_checker_credentials.private_key)}"
-  filename = "${path.module}/${google_service_account.vault_auth_checker.account_id}-credentials.json"
-}

--- a/identity/gcp-gce-auth/vault/main.tf
+++ b/identity/gcp-gce-auth/vault/main.tf
@@ -11,6 +11,7 @@ path "secret/demo" {
   capabilities = ["read"]
 }
 EOT
+
 }
 
 resource "vault_generic_secret" "demo_secret" {
@@ -22,20 +23,27 @@ resource "vault_generic_secret" "demo_secret" {
   "location": "London"
 }
 EOT
+
 }
 
 data "terraform_remote_state" "gcp_project_state" {
   backend = "local"
-  config {
+  config = {
     path = "${path.module}/../terraform.tfstate"
   }
 }
 
-resource "vault_gcp_auth_backend_role" "gcp" {
-  role                   = "web"
-  type                   = "gce"
-  backend                = "gcp"
-  project_id             = "${data.terraform_remote_state.gcp_project_state.project_id}"
-  bound_regions          = ["europe-west2"]
-  policies               = ["reader"]
+resource "vault_auth_backend" "gcp" {
+  path = "gcp"
+  type = "gcp"
 }
+
+resource "vault_gcp_auth_backend_role" "gcp" {
+  role           = "web"
+  type           = "gce"
+  backend        = "gcp"
+  bound_projects = [data.terraform_remote_state.gcp_project_state.outputs.project_id]
+  bound_regions  = ["europe-west2"]
+  policies       = ["reader"]
+}
+

--- a/identity/gcp-gce-auth/vault/versions.tf
+++ b/identity/gcp-gce-auth/vault/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
* Updates to Terraform 0.12
* Fixes the service account auth permissions
* Removes the need for a service account file