### PR TITLE
Updated for Terraform 0.12

### DIFF
--- a/identity/vault-agent-caching/terraform-aws/aws.tf
+++ b/identity/vault-agent-caching/terraform-aws/aws.tf
@@ -4,7 +4,7 @@
 provider "aws" {
   // Credentials set via env vars
 
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 //--------------------------------------------------------------------
@@ -25,3 +25,4 @@ data "aws_ami" "ubuntu" {
 
   owners = ["099720109477"] # Canonical
 }
+

--- a/identity/vault-agent-caching/terraform-aws/iam.tf
+++ b/identity/vault-agent-caching/terraform-aws/iam.tf
@@ -4,35 +4,35 @@
 ## Vault Server IAM Config
 resource "aws_iam_instance_profile" "vault-server" {
   name = "${var.environment_name}-vault-server-instance-profile"
-  role = "${aws_iam_role.vault-server.name}"
+  role = aws_iam_role.vault-server.name
 }
 
 resource "aws_iam_role" "vault-server" {
   name               = "${var.environment_name}-vault-server-role"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "vault-server" {
   name   = "${var.environment_name}-vault-server-role-policy"
-  role   = "${aws_iam_role.vault-server.id}"
-  policy = "${data.aws_iam_policy_document.vault-server.json}"
+  role   = aws_iam_role.vault-server.id
+  policy = data.aws_iam_policy_document.vault-server.json
 }
 
 # Vault Client IAM Config
 resource "aws_iam_instance_profile" "vault-client" {
   name = "${var.environment_name}-vault-client-instance-profile"
-  role = "${aws_iam_role.vault-client.name}"
+  role = aws_iam_role.vault-client.name
 }
 
 resource "aws_iam_role" "vault-client" {
   name               = "${var.environment_name}-vault-client-role"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "vault-client" {
   name   = "${var.environment_name}-vault-client-role-policy"
-  role   = "${aws_iam_role.vault-client.id}"
-  policy = "${data.aws_iam_policy_document.vault-client.json}"
+  role   = aws_iam_role.vault-client.id
+  policy = data.aws_iam_policy_document.vault-client.json
 }
 
 //--------------------------------------------------------------------
@@ -67,8 +67,8 @@ data "aws_iam_policy_document" "vault-server" {
       "ec2:DescribeInstances",
       "iam:GetInstanceProfile",
       "iam:GetUser",
-      "iam:GetRole"
-    ],
+      "iam:GetRole",
+    ]
     resources = ["*"]
   }
 
@@ -96,3 +96,4 @@ data "aws_iam_policy_document" "vault-client" {
     resources = ["*"]
   }
 }
+

--- a/identity/vault-agent-caching/terraform-aws/instances.tf
+++ b/identity/vault-agent-caching/terraform-aws/instances.tf
@@ -2,40 +2,41 @@
 # Vault Server Instance
 #--------------------------------------------------------------------
 resource "aws_instance" "vault-server" {
-  count                       = "${var.vault_server_count}"
-  ami                         = "${data.aws_ami.ubuntu.id}"
-  instance_type               = "${var.instance_type}"
-  subnet_id                   = "${module.vault_demo_vpc.public_subnets[0]}"
-  key_name                    = "${var.key_name}"
-  vpc_security_group_ids      = ["${aws_security_group.testing.id}"]
+  count                       = var.vault_server_count
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  subnet_id                   = module.vault_demo_vpc.public_subnets[0]
+  key_name                    = var.key_name
+  vpc_security_group_ids      = [aws_security_group.testing.id]
   associate_public_ip_address = true
-  iam_instance_profile        = "${aws_iam_instance_profile.vault-server.id}"
+  iam_instance_profile        = aws_iam_instance_profile.vault-server.id
 
-  tags {
+  tags = {
     Name     = "${var.environment_name}-vault-server-${count.index}"
-    ConsulDC = "${var.consul_dc}"
-    TTL      = "${var.hashibot_reaper_ttl}"
+    ConsulDC = var.consul_dc
+    TTL      = var.hashibot_reaper_ttl
   }
 
-  user_data = "${data.template_file.vault-server.rendered}"
+  user_data = data.template_file.vault-server.rendered
 
   lifecycle {
-    ignore_changes = ["ami", "tags"]
+    ignore_changes = [
+      ami,
+      tags,
+    ]
   }
 }
-
 
 resource "aws_iam_user" "vault_demo_user" {
   name = "vault_demo_user"
 }
 
 resource "aws_iam_access_key" "vault_demo_user_key" {
-  user = "${aws_iam_user.vault_demo_user.name}"
+  user = aws_iam_user.vault_demo_user.name
 }
 
 resource "aws_iam_user_policy" "vault_demo_user_policy" {
-
-  user = "${aws_iam_user.vault_demo_user.name}"
+  user = aws_iam_user.vault_demo_user.name
 
   policy = <<EOF
 {
@@ -48,64 +49,69 @@ resource "aws_iam_user_policy" "vault_demo_user_policy" {
       }
   ]
 }
-  EOF
+  
+EOF
+
 }
 
-
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "template_file" "vault-server" {
-  template = "${file("${path.module}/templates/userdata-vault-server.tpl")}"
+  template = file("${path.module}/templates/userdata-vault-server.tpl")
 
   vars = {
-    tpl_vault_zip_file          = "${var.vault_zip_file}"
-    tpl_consul_zip_file         = "${var.consul_zip_file}"
-    tpl_consul_dc               = "${var.consul_dc}"
+    tpl_vault_zip_file          = var.vault_zip_file
+    tpl_consul_zip_file         = var.consul_zip_file
+    tpl_consul_dc               = var.consul_dc
     tpl_vault_service_name      = "vault-${var.environment_name}"
-    tpl_kms_key                 = "${aws_kms_key.vault.id}"
-    tpl_aws_region              = "${var.aws_region}"
-    tpl_consul_bootstrap_expect = "${var.vault_server_count}"
-    aws_access_key_id           = "${aws_iam_access_key.vault_demo_user_key.id}"
-    aws_secret_access_key       = "${aws_iam_access_key.vault_demo_user_key.secret}"
-    account_id                  = "${data.aws_caller_identity.current.account_id}"
+    tpl_kms_key                 = aws_kms_key.vault.id
+    tpl_aws_region              = var.aws_region
+    tpl_consul_bootstrap_expect = var.vault_server_count
+    aws_access_key_id           = aws_iam_access_key.vault_demo_user_key.id
+    aws_secret_access_key       = aws_iam_access_key.vault_demo_user_key.secret
+    account_id                  = data.aws_caller_identity.current.account_id
     role_name                   = "${var.environment_name}-vault-client-role"
   }
 }
-
 
 #--------------------------------------------------------------------
 # Vault Client Instance
 #--------------------------------------------------------------------
 resource "aws_instance" "vault-client" {
-  ami                         = "${data.aws_ami.ubuntu.id}"
-  instance_type               = "${var.instance_type}"
-  subnet_id                   = "${module.vault_demo_vpc.public_subnets[0]}"
-  key_name                    = "${var.key_name}"
-  vpc_security_group_ids      = ["${aws_security_group.testing.id}"]
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  subnet_id                   = module.vault_demo_vpc.public_subnets[0]
+  key_name                    = var.key_name
+  vpc_security_group_ids      = [aws_security_group.testing.id]
   associate_public_ip_address = true
-  iam_instance_profile        = "${aws_iam_instance_profile.vault-client.id}"
+  iam_instance_profile        = aws_iam_instance_profile.vault-client.id
 
-  tags {
+  tags = {
     Name     = "${var.environment_name}-vault-client"
     ConsulDC = "consul-${var.aws_region}"
-    TTL      = "${var.hashibot_reaper_ttl}"
+    TTL      = var.hashibot_reaper_ttl
   }
 
-  user_data = "${data.template_file.vault-client.rendered}"
+  user_data = data.template_file.vault-client.rendered
 
   lifecycle {
-    ignore_changes = ["ami", "tags"]
+    ignore_changes = [
+      ami,
+      tags,
+    ]
   }
 }
 
 data "template_file" "vault-client" {
-  template = "${file("${path.module}/templates/userdata-vault-client.tpl")}"
+  template = file("${path.module}/templates/userdata-vault-client.tpl")
 
   vars = {
-    tpl_vault_zip_file     = "${var.vault_zip_file}"
-    tpl_consul_zip_file    = "${var.consul_zip_file}"
-    tpl_consul_dc          = "${var.consul_dc}"
+    tpl_vault_zip_file     = var.vault_zip_file
+    tpl_consul_zip_file    = var.consul_zip_file
+    tpl_consul_dc          = var.consul_dc
     tpl_vault_service_name = "vault-${var.environment_name}"
-    tpl_vault_server_addr  = "${aws_instance.vault-server.0.private_ip}"
+    tpl_vault_server_addr  = aws_instance.vault-server[0].private_ip
   }
 }
+

--- a/identity/vault-agent-caching/terraform-aws/kms.tf
+++ b/identity/vault-agent-caching/terraform-aws/kms.tf
@@ -5,12 +5,13 @@ resource "aws_kms_key" "vault" {
   description             = "Vault unseal key"
   deletion_window_in_days = 7
 
-  tags {
+  tags = {
     Name = "${var.environment_name}-vault-kms-unseal-key"
   }
 }
 
 resource "aws_kms_alias" "vault" {
   name          = "alias/${var.environment_name}-vault-kms-unseal-key"
-  target_key_id = "${aws_kms_key.vault.key_id}"
+  target_key_id = aws_kms_key.vault.key_id
 }
+

--- a/identity/vault-agent-caching/terraform-aws/network.tf
+++ b/identity/vault-agent-caching/terraform-aws/network.tf
@@ -4,11 +4,12 @@ module "vault_demo_vpc" {
   name = "${var.environment_name}-vpc"
   cidr = "10.0.0.0/16"
 
-  azs              = ["${var.availability_zones}"]
-  private_subnets  = ["10.0.1.0/24"]
-  public_subnets   = ["10.0.101.0/24"]
+  azs             = [var.availability_zones]
+  private_subnets = ["10.0.1.0/24"]
+  public_subnets  = ["10.0.101.0/24"]
 
   tags = {
     Name = "${var.environment_name}-vpc"
   }
 }
+

--- a/identity/vault-agent-caching/terraform-aws/outputs.tf
+++ b/identity/vault-agent-caching/terraform-aws/outputs.tf
@@ -5,7 +5,7 @@ Vault Server IP (public):  ${join(", ", aws_instance.vault-server.*.public_ip)}
 Vault Server IP (private): ${join(", ", aws_instance.vault-server.*.private_ip)}
 
 For example:
-   ssh -i ${var.key_name}.pem ubuntu@${aws_instance.vault-server.0.public_ip}
+   ssh -i ${var.key_name}.pem ubuntu@${aws_instance.vault-server[0].public_ip}
 
 Vault Client IP (public):  ${aws_instance.vault-client.public_ip}
 Vault Client IP (private): ${aws_instance.vault-client.private_ip}
@@ -13,21 +13,17 @@ Vault Client IP (private): ${aws_instance.vault-client.private_ip}
 For example:
    ssh -i ${var.key_name}.pem ubuntu@${aws_instance.vault-client.public_ip}
 EOF
-}
 
+}
 
 # output "endpoints" {
 #   value = <<EOF
-
 # Vault Server IP (public):  ${aws_instance.vault-server.*.public_ip}
 # Vault Server IP (private): ${aws_instance.vault-server.*.private_ip}
-
 # For example:
 #    ssh -i ${var.key_name}.pem ubuntu@${aws_instance.vault-server.0.public_ip}
-
 # Vault Client IP (public):  ${aws_instance.vault-client.*.public_ip}
 # Vault Client IP (private): ${aws_instance.vault-client.*.private_ip}
-
 # For example:
 #    ssh -i ${var.key_name}.pem ubuntu@${aws_instance.vault-client.public_ip}
 # EOF

--- a/identity/vault-agent-caching/terraform-aws/security-groups.tf
+++ b/identity/vault-agent-caching/terraform-aws/security-groups.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "testing" {
   name        = "${var.environment_name}-testing-sg"
   description = "SSH and Internal Traffic"
-  vpc_id      = "${module.vault_demo_vpc.vpc_id}"
+  vpc_id      = module.vault_demo_vpc.vpc_id
 
-  tags {
-    Name = "${var.environment_name}"
+  tags = {
+    Name = var.environment_name
   }
 
   # SSH
@@ -54,3 +54,4 @@ resource "aws_security_group" "testing" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+

--- a/identity/vault-agent-caching/terraform-aws/variables.tf
+++ b/identity/vault-agent-caching/terraform-aws/variables.tf
@@ -1,46 +1,49 @@
 # AWS region and AZs in which to deploy
-variable aws_region {
+variable "aws_region" {
   default = "us-east-1"
 }
-variable availability_zones {
+
+variable "availability_zones" {
   default = "us-east-1a"
 }
 
 # All resources will be tagged with this
-variable environment_name {
+variable "environment_name" {
   default = "vault-agent-demo"
 }
 
 # Consul datacenter name
-variable consul_dc {
+variable "consul_dc" {
   default = "dc1"
 }
 
 # Number of Vault servers to provision
-variable vault_server_count {
+variable "vault_server_count" {
   default = 1
 }
 
 # URL for Vault OSS binary
-variable vault_zip_file {
-    default = "https://releases.hashicorp.com/vault/1.1.0/vault_1.1.0_linux_amd64.zip"
+variable "vault_zip_file" {
+  default = "https://releases.hashicorp.com/vault/1.1.0/vault_1.1.0_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary
-variable consul_zip_file {
+variable "consul_zip_file" {
   default = "https://releases.hashicorp.com/consul/1.4.3/consul_1.4.3_linux_amd64.zip"
 }
 
 # Instance size
-variable instance_type {
+variable "instance_type" {
   default = "t2.micro"
 }
 
 # SSH key name to access EC2 instances (should already exist) in the AWS Region
-variable key_name {}
+variable "key_name" {
+}
 
 # Instance tags for HashiBot AWS resource reaper
 # variable hashibot_reaper_owner {}
-variable hashibot_reaper_ttl {
-    default = 48
+variable "hashibot_reaper_ttl" {
+  default = 48
 }
+

--- a/identity/vault-agent-caching/terraform-aws/versions.tf
+++ b/identity/vault-agent-caching/terraform-aws/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is for [Vault Agent Caching](https://learn.hashicorp.com/vault/identity-access-management/agent-caching) guide.

Updated the 0.11 terraform files to 0.12