### PR TITLE
Additional Sentinel policies

### DIFF
--- a/governance/sentinel/aws-no-keys.sentinel
+++ b/governance/sentinel/aws-no-keys.sentinel
@@ -1,0 +1,31 @@
+# EGP policy meant for paths aws/config/root and auth/aws/config/client
+# Prohibit use of AWS creds to enforce IAM profile usage only
+# Can be used for AWS auth or secrets
+
+config_check = func() {
+  # Make sure there is request data
+  if length(request.data else 0) is 0 {
+    print("No request data")
+    return false
+  }
+
+  # Debug data
+  #print("DATA:", request.data)
+
+  if ("access_key" in keys(request.data) or "secret_key" in keys(request.data)) {
+    print("Use of AWS access_key and secret_key is prohibited.  IAM profile is required.")
+    return false
+  }
+
+  return true
+}
+
+# Rule applies to creating/updating AWS Vault roles (uses default path)
+precond = rule {
+	request.operation in ["create", "update"]
+}
+
+# Main rule
+main = rule when precond {
+	config_check()
+}

--- a/governance/sentinel/max-kv-value-size.sentinel
+++ b/governance/sentinel/max-kv-value-size.sentinel
@@ -1,0 +1,57 @@
+# EGP policy meant for path secret/(data/)?.*
+# Restrict KV values to a certain size
+
+check_size = func(key, value) {
+  # Set your size here
+  max_value_size = 10
+  if (length(value) > max_value_size) {
+    print(key, "value size of", length(value), "exceeds limit of", max_value_size)
+    return 1
+  } else {
+    print(key, "value size of", length(value), "is within limit of", max_value_size)
+    return 0
+  }
+}
+
+check_kvs = func() {
+  # Make sure there is request data
+  if length(request.data else 0) is 0 {
+    print("No request data")
+    return false
+  }
+
+  # Make sure there is a data object
+  if "data" not in keys(request.data) {
+    print("No data object")
+    return false
+  }
+
+  # Debug data
+  print("DATA:", request.data.data)
+
+  # Iterate through all K/V pairs
+  fails = 0
+  for request.data.data as key, value {
+    #print("KEY:", key)
+    #print("VALUE:", value)
+    fails += check_size(key, value)
+  }
+
+  # Return false if any failures were counted
+  if fails > 0 {
+    print(fails, "failures!")
+    return false
+  }
+
+  return true
+}
+
+# Rule applies to creating/updating/patching K/V pairs
+precond = rule {
+	request.operation in ["create", "update"]
+}
+
+# Main rule
+main = rule when precond {
+	check_kvs()
+}

--- a/governance/sentinel/test/aws-no-keys/fail-auth.json
+++ b/governance/sentinel/test/aws-no-keys/fail-auth.json
@@ -1,0 +1,16 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "auth/aws/config/client",
+      "data": {
+        "max_retries": 5,
+        "access_key": "noncompliant",
+        "secret_key": "superSecret"
+      }
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/aws-no-keys/fail-secrets.json
+++ b/governance/sentinel/test/aws-no-keys/fail-secrets.json
@@ -1,0 +1,16 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "/aws/config/root",
+      "data": {
+        "max_retries": 5,
+        "access_key": "noncompliant",
+        "secret_key": "superSecret"
+      }
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/aws-no-keys/success-auth.json
+++ b/governance/sentinel/test/aws-no-keys/success-auth.json
@@ -1,0 +1,11 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "auth/aws/config/client",
+      "data": {
+        "max_retries": 5
+      }
+    }
+  }
+}

--- a/governance/sentinel/test/aws-no-keys/success-secrets.json
+++ b/governance/sentinel/test/aws-no-keys/success-secrets.json
@@ -1,0 +1,11 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "/aws/config/root",
+      "data": {
+        "max_retries": 5
+      }
+    }
+  }
+}

--- a/governance/sentinel/test/max-kv-value-size/fail.json
+++ b/governance/sentinel/test/max-kv-value-size/fail.json
@@ -1,0 +1,17 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "secret/data/stuff",
+      "data": {
+        "data": {
+          "junk": "1234567890123456789012345678901234567890",
+          "zip": "zap"
+        }
+      }
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/max-kv-value-size/success.json
+++ b/governance/sentinel/test/max-kv-value-size/success.json
@@ -1,0 +1,14 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "secret/data/stuff",
+      "data": {
+        "data": {
+          "junk": "1234567890",
+          "zip": "zap"
+        }
+      }
+    }
+  }
+}

--- a/governance/sentinel/test/userpass-password-check/fail.json
+++ b/governance/sentinel/test/userpass-password-check/fail.json
@@ -1,0 +1,15 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "secret/data/stuff",
+      "data": {
+        "password": "abc",
+        "policies": "admin,default"
+      }
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/userpass-password-check/success.json
+++ b/governance/sentinel/test/userpass-password-check/success.json
@@ -1,0 +1,12 @@
+{
+  "global": {
+    "request": {
+      "operation": "create",
+      "path": "secret/data/stuff",
+      "data": {
+        "password": "abcdABCD1234#",
+        "policies": "admin,default"
+      }
+    }
+  }
+}

--- a/governance/sentinel/userpass-password-check.sentinel
+++ b/governance/sentinel/userpass-password-check.sentinel
@@ -1,0 +1,81 @@
+# EGP policy meant for path /auth/userpass/users/*
+# Ensure strong password is being used
+# * 8-20 characters
+# * At least one lowercase letter
+# * At least one uppercase letter
+# * At least one number
+# * At least one special character
+
+check_password = func(password) {
+  # Track total failures
+  score = 0
+
+  # 8-20 characters
+  if (length(password) < 8 or length(password) > 20) {
+    print("Password should be between 8 and 20 characters.")
+    score += 1
+  }
+
+  # Lowercase letter
+  if !(password matches "[a-z]") {
+    print("Password should contain at least one lowercase letter.")
+    score += 1
+  }
+
+  # Uppercase letter
+  if !(password matches "[A-Z]") {
+    print("Password should contain at least one uppercase letter.")
+    score += 1
+  }
+
+  # Number
+  if !(password matches "[0-9]") {
+    print("Password should contain at least one number.")
+    score += 1
+  }
+  
+  # Special character
+  if !(password matches "[\\!@#\\$%\\^&\\*\\(\\)\\-=_\\+\\[\\]{};':\",\\.\\/\\?]") {
+    print("Password should contain at least one special character.")
+    score += 1
+  }
+
+  return score
+}
+
+password_policy = func() {
+  # Make sure there is request data
+  if length(request.data else 0) is 0 {
+    print("No request data")
+    return false
+  }
+
+  # Make sure there is a password
+  if "password" not in keys(request.data) {
+    print("No password")
+    return false
+  }
+
+  # Debug data
+  print("DATA:", request.data)
+  print("PASSWORD:", request.data.password)
+
+  fails = check_password(request.data.password)
+
+  if (fails > 0) {
+    print(fails, "failures!")
+    return false
+  }
+
+  return true
+}
+
+# Rule applies to creating/updating AWS Vault roles (uses default path)
+precond = rule {
+	request.operation in ["create", "update"]
+}
+
+# Main rule
+main = rule when precond {
+	password_policy()
+}


### PR DESCRIPTION
`max-kv-value-size.sentinel`: Iterate through values in KV pairs and limit size
`aws-no-keys.sentinel`: Disallow `access_key` and `secret_key` so that IAM profile must be used by Vault
`userpass-password-check.sentinel`: Enforce password requirements