### PR TITLE
add missing `vault-auth-service-account.yaml` in vault-k8s guide

### DIFF
--- a/operations/provision-vault/kubernetes/minikube/getting-started/vault-auth-service-account.yaml
+++ b/operations/provision-vault/kubernetes/minikube/getting-started/vault-auth-service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault
+  namespace: default


### PR DESCRIPTION
The `vault-auth-service-account.yaml` is based on this example, with only a different serviceAccount name.
https://www.vaultproject.io/docs/auth/kubernetes.html#configuring-kubernetes