### PR TITLE
update required or else apt-get fails on Azure.

### DIFF
--- a/identity/azure-auth/setup.tpl
+++ b/identity/azure-auth/setup.tpl
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+sudo apt update
 sudo apt-get install -y unzip jq 
 
 sudo cat << EOF > /etc/profile.d/vault.sh


### PR DESCRIPTION
I noticed that unzip and jq do not install if an apt update is not done first. It works fine on Azure with this small fix.