### PR TITLE
apt update required or else apt-get fails to install unzip and jq.

### DIFF
--- a/identity/azure-auth/setup.tpl
+++ b/identity/azure-auth/setup.tpl
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+sudo apt update
 sudo apt-get install -y unzip jq 
 
 sudo cat << EOF > /etc/profile.d/vault.sh


### PR DESCRIPTION
The script fails as it cannot install unzip and jq. It works when you do an apt update first.