### PR TITLE
increase consul_encrypt id lenght

### DIFF
--- a/operations/provision-vault/best-practices/terraform-aws/main.tf
+++ b/operations/provision-vault/best-practices/terraform-aws/main.tf
@@ -11,7 +11,7 @@ module "consul_auto_join_instance_role" {
 }
 
 resource "random_id" "consul_encrypt" {
-  byte_length = 16
+  byte_length = 32
 }
 
 module "root_tls_self_signed_ca" {


### PR DESCRIPTION
Currently, the Consul random id is set to 16 bytes.
https://github.com/hashicorp/vault-guides/blob/master/operations/provision-vault/best-practices/terraform-aws/main.tf
(search for consul_encrypt)

In the Consul documentation, they recommend to use 32 bytes.
https://www.consul.io/docs/agent/options.html
(search for -encrypt)