### PR TITLE
[Learn] Updated the .Net code for Transit Rewrap guide

### DIFF
--- a/encryption/vault-transit-rewrap/DBHelper.cs
+++ b/encryption/vault-transit-rewrap/DBHelper.cs
@@ -64,7 +64,7 @@ namespace RewrapExample
                     "(`user_name`, `first_name`, `last_name`, `address`, " +
                     "`city`, `state`, `postcode`, `email`) " +
                     $"VALUES (\"{r.Login.Username}\", \"{r.Name.First}\", \"{r.Name.Last}\", " +
-                    $"\"{r.Location.Street}\", \"{r.Location.City}\", \"{r.Location.State}\", " +
+                    $"\"{r.Location.City}\", \"{r.Location.State}\", \"{r.Location.Country}\", " +
                     $"\"{r.Location.Postcode}\", \"{r.Email}\");";
                     
                     cmd.CommandText = command;
@@ -83,7 +83,7 @@ namespace RewrapExample
                 using (var cmd = db.Connection.CreateCommand())
                 {
                     string command = "UPDATE `user_data` " + 
-                    $"SET `address` = \"{r.Location.Street}\", " +
+                    $"SET `address` = \"{r.Location.City}\", " +
                     $"`email` = \"{r.Email}\" " +
                     $"WHERE `user_id` = {r.Id.Value}";
                     
@@ -123,7 +123,7 @@ namespace RewrapExample
                         var address = reader.GetString(2);
                         
                         RewrapExample.Location addr = new Location();
-                        addr.Street = address;
+                        addr.City = address;
                         RewrapExample.Id id = new Id();
                         id.Value = user_id.ToString();
 

--- a/encryption/vault-transit-rewrap/DBHelper.cs
+++ b/encryption/vault-transit-rewrap/DBHelper.cs
@@ -20,9 +20,9 @@ namespace RewrapExample
                         "`user_name` VARCHAR(256) NOT NULL," +
                         "`first_name` VARCHAR(256) NULL, " +
                         "`last_name` VARCHAR(256) NULL, " +
-                        "`address` VARCHAR(256) NOT NULL, " +
                         "`city` VARCHAR(256) NOT NULL," +
                         "`state` VARCHAR(256) NOT NULL," +
+                        "`country` VARCHAR(256) NOT NULL," +
                         "`postcode` VARCHAR(256) NOT NULL," +
                         "`email` VARCHAR(256) NOT NULL," +
                         "PRIMARY KEY (user_id) " +
@@ -61,8 +61,8 @@ namespace RewrapExample
                 {
                     
                     string command = "INSERT INTO `user_data` " + 
-                    "(`user_name`, `first_name`, `last_name`, `address`, " +
-                    "`city`, `state`, `postcode`, `email`) " +
+                    "(`user_name`, `first_name`, `last_name`, " +
+                    "`city`, `state`, `country`, `postcode`, `email`) " +
                     $"VALUES (\"{r.Login.Username}\", \"{r.Name.First}\", \"{r.Name.Last}\", " +
                     $"\"{r.Location.City}\", \"{r.Location.State}\", \"{r.Location.Country}\", " +
                     $"\"{r.Location.Postcode}\", \"{r.Email}\");";
@@ -83,13 +83,12 @@ namespace RewrapExample
                 using (var cmd = db.Connection.CreateCommand())
                 {
                     string command = "UPDATE `user_data` " + 
-                    $"SET `address` = \"{r.Location.City}\", " +
+                    $"SET `city` = \"{r.Location.City}\", " +
                     $"`email` = \"{r.Email}\" " +
                     $"WHERE `user_id` = {r.Id.Value}";
                     
                     cmd.CommandText = command;
-                    Console.WriteLine("Command: " + command);
-
+                    
                     await cmd.ExecuteNonQueryAsync();
                 }
             }
@@ -106,10 +105,10 @@ namespace RewrapExample
                 using (var cmd = db.Connection.CreateCommand())
                 {
                     int count = 0;
-                    string command = "SELECT `user_id`, `email`, `address` " +
+                    string command = "SELECT `user_id`, `email`, `city` " +
                     "FROM `user_data` " + 
                     $"WHERE `email` NOT LIKE \"vault:v{keyVersion}:%\" " + 
-                    $"OR `address` NOT LIKE \"vault:v{keyVersion}:%\" ";
+                    $"OR `city` NOT LIKE \"vault:v{keyVersion}:%\" ";
                         
                     cmd.CommandText = command;
 
@@ -120,10 +119,10 @@ namespace RewrapExample
                         count++;
                         var user_id = reader.GetInt32(0);
                         var email = reader.GetString(1);
-                        var address = reader.GetString(2);
+                        var city = reader.GetString(2);
                         
                         RewrapExample.Location addr = new Location();
-                        addr.City = address;
+                        addr.City = city;
                         RewrapExample.Id id = new Id();
                         id.Value = user_id.ToString();
 

--- a/encryption/vault-transit-rewrap/Program.cs
+++ b/encryption/vault-transit-rewrap/Program.cs
@@ -55,7 +55,7 @@ namespace RewrapExample
             var tasks = new List<Task>();
             foreach (var record in apiResults.Records) {
                 ICollection<Task> encryptValues = new List<Task>();
-                record.Location.Street = await client.EncryptValue(record.Location.Street);
+                record.Location.City = await client.EncryptValue(record.Location.City);
                 record.Email = await client.EncryptValue(record.Email);
                 tasks.Add(DBHelper.InsertRecordAsyc(record));
             }

--- a/encryption/vault-transit-rewrap/Record.cs
+++ b/encryption/vault-transit-rewrap/Record.cs
@@ -9,9 +9,9 @@ namespace RewrapExample
 
     public class Location
     {
-        public string Country { get; set; }
         public string City { get; set; }
         public string State { get; set; }
+        public string Country { get; set; }
         public string Postcode { get; set; }
     }
 

--- a/encryption/vault-transit-rewrap/Record.cs
+++ b/encryption/vault-transit-rewrap/Record.cs
@@ -9,7 +9,7 @@ namespace RewrapExample
 
     public class Location
     {
-        public string Street { get; set; }
+        public string Country { get; set; }
         public string City { get; set; }
         public string State { get; set; }
         public string Postcode { get; set; }

--- a/encryption/vault-transit-rewrap/VaultClient.cs
+++ b/encryption/vault-transit-rewrap/VaultClient.cs
@@ -66,7 +66,7 @@ namespace RewrapExample
             foreach (Record user in users)
             {
                 count++;
-                user.Location.Street = await ReWrapValue(user.Location.Street);
+                user.Location.City = await ReWrapValue(user.Location.City);
                 user.Email = await ReWrapValue(user.Email);
                 
                 tasks.Add(DBHelper.UpdateRecordAsyc(user));


### PR DESCRIPTION
The sample code was broken due to the data change in the random data service. 

The `street` value used to be a "string" but now it's an object with `number` and `name` which caused the code to fail. 