### PR TITLE
[Learn] Updates to Vault 1.4.0-rc1 binary

### DIFF
--- a/identity/vault-agent-caching/terraform-aws/variables.tf
+++ b/identity/vault-agent-caching/terraform-aws/variables.tf
@@ -24,12 +24,12 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.3.0/vault_1.3.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary
 variable "consul_zip_file" {
-  default = "https://releases.hashicorp.com/consul/1.4.3/consul_1.4.3_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/consul/1.7.2/consul_1.7.2_linux_amd64.zip"
 }
 
 # Instance size

--- a/identity/vault-agent-demo/terraform-aws/variables.tf
+++ b/identity/vault-agent-demo/terraform-aws/variables.tf
@@ -24,12 +24,12 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.3.0/vault_1.3.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary
 variable "consul_zip_file" {
-  default = "https://releases.hashicorp.com/consul/1.4.4/consul_1.4.4_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/consul/1.7.2/consul_1.7.2_linux_amd64.zip"
 }
 
 # Instance size

--- a/identity/vault-agent-templates/terraform-aws/variables.tf
+++ b/identity/vault-agent-templates/terraform-aws/variables.tf
@@ -24,12 +24,12 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.3.0/vault_1.3.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary
 variable "consul_zip_file" {
-  default = "https://releases.hashicorp.com/consul/1.4.4/consul_1.4.4_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/consul/1.7.2/consul_1.7.2_linux_amd64.zip"
 }
 
 # Instance size

--- a/operations/aws-kms-unseal/terraform-aws/variables.tf
+++ b/operations/aws-kms-unseal/terraform-aws/variables.tf
@@ -7,7 +7,7 @@ variable "aws_zone" {
 }
 
 variable "vault_url" {
-  default = "https://releases.hashicorp.com/vault/1.3.0/vault_1.3.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
 }
 
 variable "vpc_cidr" {

--- a/operations/azure-keyvault-unseal/variables.tf
+++ b/operations/azure-keyvault-unseal/variables.tf
@@ -43,7 +43,7 @@ variable "vm_name" {
 }
 
 variable "vault_download_url" {
-  default = "https://releases.hashicorp.com/vault/1.3.0/vault_1.3.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
 }
 
 variable "resource_group_name" {

--- a/operations/gcp-kms-unseal/variables.tf
+++ b/operations/gcp-kms-unseal/variables.tf
@@ -1,5 +1,5 @@
 variable "vault_url" {
-  default = "https://releases.hashicorp.com/vault/1.3.0/vault_1.3.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
 }
 
 variable "gcloud-project" {

--- a/operations/raft-storage/aws/variables.tf
+++ b/operations/raft-storage/aws/variables.tf
@@ -34,7 +34,7 @@ variable "vault_server_private_ips" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.3.1/vault_1.3.1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
 }
 
 # Instance size


### PR DESCRIPTION
Only for those Terraform files that I use for Learn guides, I upgraded the Vault binary version to 1.4.0-rc1 for education purposes. 

**NOTE:** I did not touch other folders.