### PR TITLE
Download Vault 1.4.0 binary

### DIFF
--- a/identity/vault-agent-caching/terraform-aws/variables.tf
+++ b/identity/vault-agent-caching/terraform-aws/variables.tf
@@ -24,7 +24,7 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary

--- a/identity/vault-agent-demo/terraform-aws/variables.tf
+++ b/identity/vault-agent-demo/terraform-aws/variables.tf
@@ -24,7 +24,7 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary

--- a/identity/vault-agent-templates/terraform-aws/variables.tf
+++ b/identity/vault-agent-templates/terraform-aws/variables.tf
@@ -24,7 +24,7 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary

--- a/operations/aws-kms-unseal/terraform-aws/variables.tf
+++ b/operations/aws-kms-unseal/terraform-aws/variables.tf
@@ -7,7 +7,7 @@ variable "aws_zone" {
 }
 
 variable "vault_url" {
-  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
 }
 
 variable "vpc_cidr" {

--- a/operations/azure-keyvault-unseal/variables.tf
+++ b/operations/azure-keyvault-unseal/variables.tf
@@ -43,7 +43,7 @@ variable "vm_name" {
 }
 
 variable "vault_download_url" {
-  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
 }
 
 variable "resource_group_name" {

--- a/operations/gcp-kms-unseal/variables.tf
+++ b/operations/gcp-kms-unseal/variables.tf
@@ -1,5 +1,5 @@
 variable "vault_url" {
-  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
 }
 
 variable "gcloud-project" {

--- a/operations/raft-storage/aws/variables.tf
+++ b/operations/raft-storage/aws/variables.tf
@@ -34,7 +34,7 @@ variable "vault_server_private_ips" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
 }
 
 # Instance size


### PR DESCRIPTION
Updating the Terraform files that are used for Learn guides to download the Vault 1.4.0 GA binary.