### PR TITLE
Fix the setting of the VAULT_SERVICE env var in vault-raft user data

### DIFF
--- a/operations/raft-storage/aws/templates/userdata-vault-server.tpl
+++ b/operations/raft-storage/aws/templates/userdata-vault-server.tpl
@@ -197,7 +197,7 @@ sudo setcap cap_ipc_lock=+ep /usr/local/bin/vault
 ##--------------------------------------------------------------------
 ## Install Vault Systemd Service
 
-sudo tee /etc/systemd/system/vault.service > /dev/null <<EOF
+read -d '' VAULT_SERVICE <<EOF
 [Unit]
 Description=Vault
 Requires=network-online.target


### PR DESCRIPTION
Based on other uses of the VAULT_SERVICE environment variable in this
repository, it appears that this was originally a typo in the vault server userdata script. This changes fixes this typo so that the Vault systemd service is not turned into an empty file when the empty value of VAULT_SERVICE is used later in the script.

Examples of the correct usage of this variable in other scripts include:

https://github.com/hashicorp/vault-guides/blob/9febcfd08afd4f16590db7946d1910b90111221a/identity/vault-agent-templates/terraform-aws/templates/userdata-vault-server.tpl#L363
https://github.com/hashicorp/vault-guides/blob/0d57778c49db8b8bd8369b9cc45d9337a272d937/identity/vault-agent-caching/terraform-aws/templates/userdata-vault-server.tpl#L361