### PR TITLE
add prevent-kv-v1-engines.sentinel

### DIFF
--- a/governance/sentinel/README.md
+++ b/governance/sentinel/README.md
@@ -28,23 +28,32 @@ sentinel test
 
 File | Description | Application
 --- | --- | ---
-egp-cidr-payload.json | Contains base64 enconded Sentinel policy, to be applied to all secrets | Used to register the Sentinel policy within Vault
-egp-businesshours-payload.json | Contains base64 enconded Sentinel policy, to be applied to the "accounting" secrets | Used to register the Sentinel policy within Vault
-cidr-policy.sentinel | Sentinel policy that checks request's IP | Needs to be converted to base64 prior to be added to *egp-cidr-payload.json*
+aws-no-keys.sentinel | Sentinel policy that prevents explicit use of AWS keys when creating an instance of the AWS secrets engine or the AWS auth method | Needs to be converted to base64 prior to being added with the Vault HTTP API
 businesshours-policy.sentinel | Sentinel policy that checks request's time | Needs to be converted to base64 prior to be added to *egp-time-payload.json*
+cidr-policy.sentinel | Sentinel policy that checks request's IP | Needs to be converted to base64 prior to be added to *egp-cidr-payload.json*
+egp-businesshours-payload.json | Contains base64 enconded Sentinel policy, to be applied to the "accounting" secrets | Used to register the Sentinel policy within Vault
+egp-cidr-payload.json | Contains base64 enconded Sentinel policy, to be applied to all secrets | Used to register the Sentinel policy within Vault
+egp-okta-user-whitelist.sentinel | Sentinel policy that gives whitelist of approved users that can authenticate with the Okta auth method | Needs to be converted to base64 prior to being added with the Vault HTTP API
+inline-iam-actions.sentinel | Sentinel policy that restricts inline AWS IAM policies to only designate ec2 actions | Needs to be converted to base64 prior to being added with the Vault HTTP API
+inline-iam-resources.sentinel | Sentinel policy that restricts inline AWS IAM policies from using a wildcard in resources | Needs to be converted to base64 prior to being added with the Vault HTTP API
+max-kv-value-size.sentinel | Sentinel policy that restricts the size of keys written to KVv2 secrets | Needs to be converted to base64 prior to being added with the Vault HTTP API
 my-acl-policy.json | ACL policy to be associated to an user | This policy will allow access to the secret path that will be protected by Sentinel
+prevent-kv-v1-engines.sentinel | Sentinel policy that prevents KVv1 secrets engines from being created in any namespace | This should be deployed in the root namespace and needs to be converted to base64 prior to being added with the Vault HTTP API
 secret-example.json | Value representing sensitive information to be stored in Vault | Used to test if user can read/write a secret when Sentinel policy is in place
-userpass-auth-payload.json | userpass auth method payload | Used to enable userpass authentication method for our tests
 user-password.json | Contains user password | Used to create a new user with the permissive ACL policy
 user-payload | Information to create an user | This user will test the Sentinel check
+userpass-auth-payload.json | userpass auth method payload | Used to enable userpass authentication method for our tests
+userpass-password-check.sentinel | Sentinel policy that requires strong passwords for the Userpass auth method | Needs to be converted to base64 prior to being added with the Vault HTTP API
 
 ### Base64
-The Sentinel policy needs to be encoded as a base64 string prior to submitting to Vault. In this repository the Sentinel policy "cidr-policy.sentinel" is already encoded, however if you would like to change or use your own you can run the following command:
+The Sentinel policy needs to be encoded as a base64 string prior to submitting to Vault with the Vault HTTP API. In this repository the Sentinel policy "cidr-policy.sentinel" and a few others are already encoded, however if you would like to change or use your own you can run the following command:
 ```
 cat cidr-policy.sentinel | base64
 cat businesshours-policy.sentinel | base64
 ```
 Or you can use a free online service such as https://www.base64decode.org/ to encode/decode a string.
+
+You do not need to encode policies if you add them in the Vault UI.
 
 ## Steps
 

--- a/governance/sentinel/prevent-kv-v1-engines.sentinel
+++ b/governance/sentinel/prevent-kv-v1-engines.sentinel
@@ -1,0 +1,32 @@
+# Function that validates AWS keys
+prevent_kv_v1_engines = func() {
+
+  # Print some information about the request
+  # Note that these messages will only be printed when the policy is violated
+  print("Namespace path:", namespace.path)
+  print("Request path:", request.path)
+  print("Request data:", request.data)
+
+  # Validate that path includes sys/mounts
+  if request.path matches "^(.*)sys\\/mounts\\/(.*)$" and
+     ("type" in keys(request.data) and request.data.type is "kv") and
+     request.operation in ["create", "update"] {
+    print("type of secrets engine:", request.data.type)
+    if (request.data.options else null is null) or 
+       ("version" in keys(request.data.options) and request.data.options.version is "1") {
+      print("The version of the KV secrets engine is 1 which is not allowed.")
+      print("Please set version to 2 or create engine with type kv-v2")
+      return false
+    }
+    return true
+  }
+
+  return true
+
+}
+
+# Main Rule
+secrets_engines_validated = prevent_kv_v1_engines()
+main = rule {
+  secrets_engines_validated
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/fail-Sales-SE-no-version.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/fail-Sales-SE-no-version.json
@@ -1,0 +1,29 @@
+{
+  "global": {
+    "namespace": {
+      "path": "Sales/SE"
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": {
+        },
+        "seal_wrap": false,
+        "type": "kv"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/fail-Sales-SE-version-1.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/fail-Sales-SE-version-1.json
@@ -1,0 +1,30 @@
+{
+  "global": {
+    "namespace": {
+      "path": "Sales/SE"
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": {
+          "version": "1"
+        },
+        "seal_wrap": false,
+        "type": "kv"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/fail-root-no-version.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/fail-root-no-version.json
@@ -1,0 +1,28 @@
+{
+  "global": {
+    "namespace": {
+      "path": ""
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": null,
+        "seal_wrap": false,
+        "type": "kv"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/fail-root-version-1.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/fail-root-version-1.json
@@ -1,0 +1,30 @@
+{
+  "global": {
+    "namespace": {
+      "path": ""
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": {
+          "version": "1"
+        },
+        "seal_wrap": false,
+        "type": "kv"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/pass-Sales-SE-kv-v2.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/pass-Sales-SE-kv-v2.json
@@ -1,0 +1,29 @@
+{
+  "global": {
+    "namespace": {
+      "path": "Sales/SE"
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": {
+        },
+        "seal_wrap": false,
+        "type": "kv-v2"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/pass-Sales-SE-version-2.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/pass-Sales-SE-version-2.json
@@ -1,0 +1,30 @@
+{
+  "global": {
+    "namespace": {
+      "path": "Sales/SE"
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": {
+          "version": "2"
+        },
+        "seal_wrap": false,
+        "type": "kv"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/pass-root-kv-v2.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/pass-root-kv-v2.json
@@ -1,0 +1,30 @@
+{
+  "global": {
+    "namespace": {
+      "path": ""
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": {
+          "version": "2"
+        },
+        "seal_wrap": false,
+        "type": "kv-v2"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/sentinel/test/prevent-kv-v1-engines/pass-root-version-2.json
+++ b/governance/sentinel/test/prevent-kv-v1-engines/pass-root-version-2.json
@@ -1,0 +1,30 @@
+{
+  "global": {
+    "namespace": {
+      "path": ""
+    },
+    "request": {
+      "path": "sys/mounts/test-kv",
+      "data": {
+        "config": {
+          "default_lease_ttl": "0s",
+          "force_no_cache": false,
+          "max_lease_ttl": "0s",
+          "options": null
+        },
+        "description": "",
+        "external_entropy_access": false,
+        "local": false,
+        "options": {
+          "version": "2"
+        },
+        "seal_wrap": false,
+        "type": "kv"
+      },
+      "operation": "update"
+    }
+  },
+  "test": {
+    "main": true
+  }
+}


### PR DESCRIPTION
Added a  policy that prevents KV-v1 secrets engines from being created while allowing KV-v2 secrets engines to be created.  Includes test cases.