### PR TITLE
Adds the AWS scenario for password policies

### DIFF
--- a/secrets/password-policies/aws/README.md
+++ b/secrets/password-policies/aws/README.md
@@ -93,7 +93,7 @@ Engines](https://learn.hashicorp.com/vault/secrets/password-policies) guide.
 
 ## Clean up
 
-When you are done exploring, execute the `terraform destroy` command to terminal all AWS elements:
+When you are done exploring, execute the `terraform destroy` command to terminate all AWS elements:
 
 ```plaintext
 $ terraform destroy -auto-approve

--- a/secrets/password-policies/aws/README.md
+++ b/secrets/password-policies/aws/README.md
@@ -1,0 +1,100 @@
+# Password Policies
+
+These assets are provided to perform the tasks described in the [User
+Configurable Password Generation for Secret
+Engines](https://learn.hashicorp.com/vault/secrets/password-policies) guide.
+
+## Setup
+
+1.  Set your AWS credentials as environment variables:
+
+    ```plaintext
+    $ export AWS_ACCESS_KEY_ID = "<YOUR_AWS_ACCESS_KEY_ID>"
+    $ export AWS_SECRET_ACCESS_KEY = "<YOUR_AWS_SECRET_ACCESS_KEY>"
+    ```
+
+1.  Use the provided `terraform.tfvars.example` as a base to create a file named
+    `terraform.tfvars` and specify the `key_name`. Be sure to set the correct
+    [key
+    pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
+    name created in the AWS region that you are using.
+
+    Example `terrafrom.tfvars`:
+
+    ```shell
+    # SSH key name to access EC2 instances (should already exist) on the AWS region
+    key_name = "vault-test"
+
+    # If you want to use a different AWS region
+    aws_region = "us-west-1"
+    availability_zones = "us-west-1a"
+    ```
+
+1.  Run Terraform commands to provision your cloud resources:
+
+    ```plaintext
+    $ terraform init
+
+    $ terraform plan
+
+    $ terraform apply -auto-approve
+    ```
+
+    The Terraform output will display the IP addresses of the provisioned Vault nodes.
+
+    ```plaintext
+    NOTE: While Terraform's work is done, the Vault server needs time to complete
+          its own installation and configuration. Progress is reported within
+          the log file `/var/log/tf-user-data.log` and reports 'Complete' when
+          the instance is ready.
+
+    vault-server (52.53.130.188) | internal: (10.0.101.21)
+        - Initialized and unsealed.
+        - The root token is stored in /home/ubuntu/root_key
+        - The unseal key is stored in /home/ubuntu/unseal_keys
+
+        $ ssh -l ubuntu 52.53.130.188 -i <path/to/key.pem>
+
+    ```
+
+## Generate RabbitMQ users
+
+1.  SSH into the Vault server.
+
+    ```sh
+    $ ssh -l ubuntu 52.53.130.188 -i <path/to/key.pem>
+    ```
+
+1.  Generate a RabbitMQ user without password policy
+
+    ```sh
+    $ vault read rabbitmq-no-policy/creds/example
+    Key                Value
+    ---                -----
+    lease_id           rabbitmq-no-policy/creds/example/pJXck84xmbZ7psIba3xb2hg4
+    lease_duration     768h
+    lease_renewable    true
+    password           oorqjJo2XfcKZjWyW5ZMF4ytEp58yj8msplU
+    username           root-48e7b8a5-8681-2eca-2dd5-a1ceddaf8765
+    ```
+
+1.  Create a RabbitMQ user with password policy
+
+    ```sh
+    $ vault read rabbitmq-with-policy/creds/example
+    Key                Value
+    ---                -----
+    lease_id           rabbitmq-with-policy/creds/example/e2BTktqakyRwRNRJVV2h46a8
+    lease_duration     768h
+    lease_renewable    true
+    password           0vCReyis*2GztJaefxCN
+    username           root-b34542c6-2e88-f466-a3ca-3778c8bbf8b8
+    ```
+
+## Clean up
+
+When you are done exploring, execute the `terraform destroy` command to terminal all AWS elements:
+
+```plaintext
+$ terraform destroy -auto-approve
+```

--- a/secrets/password-policies/aws/iam.tf
+++ b/secrets/password-policies/aws/iam.tf
@@ -1,0 +1,85 @@
+//--------------------------------------------------------------------
+// Resources
+
+# Vault Server IAM Config
+resource "aws_iam_instance_profile" "vault-server" {
+  name = "${var.environment_name}-vault-server-instance-profile"
+  role = aws_iam_role.vault-server.name
+}
+
+resource "aws_iam_role" "vault-server" {
+  name               = "${var.environment_name}-vault-server-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy" "vault-server" {
+  name   = "${var.environment_name}-vault-server-role-policy"
+  role   = aws_iam_role.vault-server.id
+  policy = data.aws_iam_policy_document.vault-server.json
+}
+
+# Remote Host
+resource "aws_iam_instance_profile" "remote-host" {
+  name = "${var.environment_name}-remote-host-instance-profile"
+  role = aws_iam_role.remote-host.name
+}
+
+resource "aws_iam_role" "remote-host" {
+  name               = "${var.environment_name}-remote-host-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy" "remote-host" {
+  name   = "${var.environment_name}-remote-host-role-policy"
+  role   = aws_iam_role.remote-host.id
+  policy = data.aws_iam_policy_document.remote-host.json
+}
+
+//--------------------------------------------------------------------
+// Data Sources
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "vault-server" {
+  statement {
+    sid    = "1"
+    effect = "Allow"
+
+    actions = ["ec2:DescribeInstances"]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "VaultAWSAuthMethod"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstances",
+      "iam:GetInstanceProfile",
+      "iam:GetUser",
+      "iam:GetRole",
+    ]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "remote-host" {
+  statement {
+    sid    = "1"
+    effect = "Allow"
+
+    actions = ["ec2:DescribeInstances"]
+
+    resources = ["*"]
+  }
+}

--- a/secrets/password-policies/aws/main.tf
+++ b/secrets/password-policies/aws/main.tf
@@ -1,0 +1,48 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+//--------------------------------------------------------------------
+// Vault Server Instance
+
+resource "aws_instance" "vault-server" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  subnet_id                   = module.vault_demo_vpc.public_subnets[0]
+  key_name                    = var.key_name
+  vpc_security_group_ids      = [ aws_security_group.testing.id ]
+  associate_public_ip_address = true
+  private_ip                  = var.vault_server_private_ip
+  iam_instance_profile        = aws_iam_instance_profile.vault-server.id
+
+  user_data = templatefile("${path.module}/templates/userdata-vault-server.tpl", {
+    tpl_vault_node_name = "vault-server",
+    tpl_vault_storage_path = "/vault/vault-server",
+    tpl_vault_binary_url = var.vault_binary_url,
+    tpl_configure_vault_server = var.configure_vault_server
+  })
+
+  tags = {
+    Name = "${var.environment_name}-vault-server"
+  }
+
+  lifecycle {
+    ignore_changes = [ami, tags]
+  }
+}

--- a/secrets/password-policies/aws/network.tf
+++ b/secrets/password-policies/aws/network.tf
@@ -1,0 +1,15 @@
+module "vault_demo_vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "${var.environment_name}-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = [var.availability_zones]
+  private_subnets = ["10.0.1.0/24"]
+  public_subnets  = ["10.0.101.0/24"]
+
+  tags = {
+    Name = "${var.environment_name}-vpc"
+  }
+}
+

--- a/secrets/password-policies/aws/outputs.tf
+++ b/secrets/password-policies/aws/outputs.tf
@@ -1,0 +1,17 @@
+output "endpoints" {
+  value = <<EOF
+
+  NOTE: While Terraform's work is done, the Vault server needs time to complete
+        its own installation and configuration. Progress is reported within
+        the log file `/var/log/tf-user-data.log` and reports 'Complete' when
+        the instance is ready.
+
+  vault-server (${aws_instance.vault-server.public_ip})
+    - Initialized and unsealed.
+    - The root token is stored in /home/ubuntu/root_key
+    - The unseal key is stored in /home/ubuntu/unseal_keys
+
+    $ ssh -l ubuntu ${aws_instance.vault-server.public_ip} -i ${var.key_name}.pem
+
+EOF
+}

--- a/secrets/password-policies/aws/security-groups.tf
+++ b/secrets/password-policies/aws/security-groups.tf
@@ -1,0 +1,49 @@
+resource "aws_security_group" "testing" {
+  name        = "${var.environment_name}-testing-sg"
+  description = "SSH and Internal Traffic"
+  vpc_id      = module.vault_demo_vpc.vpc_id
+
+  tags = {
+    Name = var.environment_name
+  }
+
+  # SSH
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Vault API traffic
+  ingress {
+    from_port   = 8200
+    to_port     = 8200
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Vault cluster traffic
+  ingress {
+    from_port   = 8201
+    to_port     = 8201
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Internal Traffic
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+

--- a/secrets/password-policies/aws/templates/userdata-vault-server.tpl
+++ b/secrets/password-policies/aws/templates/userdata-vault-server.tpl
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+set -x
+exec > >(tee /var/log/tf-user-data.log|logger -t user-data ) 2>&1
+
+logger() {
+  DT=$(date '+%Y/%m/%d %H:%M:%S')
+  echo "$DT $0: $1"
+}
+
+logger "Running"
+
+##--------------------------------------------------------------------
+## Variables
+
+# Get Private IP address
+PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+
+# Detect package management system.
+YUM=$(which yum 2>/dev/null)
+APT_GET=$(which apt-get 2>/dev/null)
+
+##--------------------------------------------------------------------
+## Functions
+
+user_rhel() {
+  # RHEL/CentOS user setup
+  sudo /usr/sbin/groupadd --force --system $${USER_GROUP}
+
+  if ! getent passwd $${USER_NAME} >/dev/null ; then
+    sudo /usr/sbin/adduser \
+      --system \
+      --gid $${USER_GROUP} \
+      --home $${USER_HOME} \
+      --no-create-home \
+      --comment "$${USER_COMMENT}" \
+      --shell /bin/false \
+      $${USER_NAME}  >/dev/null
+  fi
+}
+
+user_ubuntu() {
+  # UBUNTU user setup
+  if ! getent group $${USER_GROUP} >/dev/null
+  then
+    sudo addgroup --system $${USER_GROUP} >/dev/null
+  fi
+
+  if ! getent passwd $${USER_NAME} >/dev/null
+  then
+    sudo adduser \
+      --system \
+      --disabled-login \
+      --ingroup $${USER_GROUP} \
+      --home $${USER_HOME} \
+      --no-create-home \
+      --gecos "$${USER_COMMENT}" \
+      --shell /bin/false \
+      $${USER_NAME}  >/dev/null
+  fi
+}
+
+##--------------------------------------------------------------------
+## Install Base Prerequisites
+
+logger "Setting timezone to UTC"
+sudo timedatectl set-timezone UTC
+
+if [[ ! -z $${YUM} ]]; then
+  logger "RHEL/CentOS system detected"
+  logger "Performing updates and installing prerequisites"
+  sudo yum-config-manager --enable rhui-REGION-rhel-server-releases-optional
+  sudo yum-config-manager --enable rhui-REGION-rhel-server-supplementary
+  sudo yum-config-manager --enable rhui-REGION-rhel-server-extras
+  sudo yum -y check-update
+  sudo yum install -q -y wget unzip bind-utils ruby rubygems ntp jq
+  sudo systemctl start ntpd.service
+  sudo systemctl enable ntpd.service
+elif [[ ! -z $${APT_GET} ]]; then
+  logger "Debian/Ubuntu system detected"
+  logger "Performing updates and installing prerequisites"
+  sudo apt-get -qq -y update
+  sudo apt-get install -qq -y wget unzip dnsutils ruby rubygems ntp jq
+  sudo systemctl start ntp.service
+  sudo systemctl enable ntp.service
+  logger "Disable reverse dns lookup in SSH"
+  sudo sh -c 'echo "\nUseDNS no" >> /etc/ssh/sshd_config'
+  sudo service ssh restart
+else
+  logger "Prerequisites not installed due to OS detection failure"
+  exit 1;
+fi
+
+##--------------------------------------------------------------------
+## Install AWS-Specific Prerequisites
+
+if [[ ! -z $${YUM} ]]; then
+  logger "RHEL/CentOS system detected"
+  logger "Performing updates and installing prerequisites"
+  curl --silent -O https://bootstrap.pypa.io/get-pip.py
+  sudo python get-pip.py
+  sudo pip install awscli
+elif [[ ! -z $${APT_GET} ]]; then
+  logger "Debian/Ubuntu system detected"
+  logger "Performing updates and installing prerequisites"
+  sudo apt-get -qq -y update
+  sudo apt-get install -qq -y awscli
+else
+  logger "AWS Prerequisites not installed due to OS detection failure"
+  exit 1;
+fi
+
+
+##--------------------------------------------------------------------
+## Configure Vault user
+
+USER_NAME="vault"
+USER_COMMENT="HashiCorp Vault user"
+USER_GROUP="vault"
+USER_HOME="/srv/vault"
+
+if [[ ! -z $${YUM} ]]; then
+  logger "Setting up user $${USER_NAME} for RHEL/CentOS"
+  user_rhel
+elif [[ ! -z $${APT_GET} ]]; then
+  logger "Setting up user $${USER_NAME} for Debian/Ubuntu"
+  user_ubuntu
+else
+  logger "$${USER_NAME} user not created due to OS detection failure"
+  exit 1;
+fi
+
+##--------------------------------------------------------------------
+## Install Vault
+
+logger "Vault: download"
+
+VAULT_BINARY_URL=${tpl_vault_binary_url}
+VAULT_BINARY_FILE=$(basename $${VAULT_BINARY_URL})
+wget -P /tmp/ $${VAULT_BINARY_URL}
+
+logger "Vault: install"
+
+if [[ $${VAULT_BINARY_FILE} =~ \.zip$ ]]; then
+  sudo unzip -o /tmp/$${VAULT_BINARY_FILE} -d /usr/local/bin/
+else
+  sudo cp /tmp/$${VAULT_BINARY_FILE} /usr/local/bin
+fi
+
+sudo chmod 0755 /usr/local/bin/vault
+sudo chown vault:vault /usr/local/bin/vault
+sudo mkdir -pm 0755 /etc/vault.d
+sudo mkdir -pm 0755 /etc/ssl/vault
+
+logger "/usr/local/bin/vault --version: $(/usr/local/bin/vault --version)"
+
+logger "Vault: configure"
+
+sudo mkdir -pm 0755 ${tpl_vault_storage_path}
+sudo chown -R vault:vault ${tpl_vault_storage_path}
+sudo chmod -R a+rwx ${tpl_vault_storage_path}
+
+sudo tee /etc/vault.d/vault.hcl <<EOF
+storage "raft" {
+  path    = "${tpl_vault_storage_path}"
+  node_id = "${tpl_vault_node_name}"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:8200"
+  cluster_address     = "0.0.0.0:8201"
+  tls_disable = true
+}
+
+api_addr = "http://$${PUBLIC_IP}:8200"
+cluster_addr = "http://$${PRIVATE_IP}:8201"
+disable_mlock = true
+ui=true
+EOF
+
+sudo chown -R vault:vault /etc/vault.d /etc/ssl/vault
+sudo chmod -R 0644 /etc/vault.d/*
+
+sudo tee -a /etc/environment <<EOF
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_SKIP_VERIFY=true
+EOF
+
+source /etc/environment
+
+logger "Granting mlock syscall to vault binary"
+sudo setcap cap_ipc_lock=+ep /usr/local/bin/vault
+
+##--------------------------------------------------------------------
+## Install Vault Systemd Service
+
+read -d '' VAULT_SERVICE <<EOF
+[Unit]
+Description=Vault
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+PermissionsStartOnly=true
+ExecStartPre=/sbin/setcap 'cap_ipc_lock=+ep' /usr/local/bin/vault
+ExecStart=/usr/local/bin/vault server -config /etc/vault.d
+ExecReload=/bin/kill -HUP \$MAINPID
+KillSignal=SIGTERM
+User=vault
+Group=vault
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+##--------------------------------------------------------------------
+## Install Vault Systemd Service that allows additional params/args
+
+sudo tee /etc/systemd/system/vault@.service > /dev/null <<EOF
+[Unit]
+Description=Vault
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Environment="OPTIONS=%i"
+Restart=on-failure
+PermissionsStartOnly=true
+ExecStartPre=/sbin/setcap 'cap_ipc_lock=+ep' /usr/local/bin/vault
+ExecStart=/usr/local/bin/vault server -config /etc/vault.d \$OPTIONS
+ExecReload=/bin/kill -HUP \$MAINPID
+KillSignal=SIGTERM
+User=vault
+Group=vault
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+
+if [[ ! -z $${YUM} ]]; then
+  SYSTEMD_DIR="/etc/systemd/system"
+  logger "Installing systemd services for RHEL/CentOS"
+  echo "$${VAULT_SERVICE}" | sudo tee $${SYSTEMD_DIR}/vault.service
+  sudo chmod 0664 $${SYSTEMD_DIR}/vault*
+elif [[ ! -z $${APT_GET} ]]; then
+  SYSTEMD_DIR="/lib/systemd/system"
+  logger "Installing systemd services for Debian/Ubuntu"
+  echo "$${VAULT_SERVICE}" | sudo tee $${SYSTEMD_DIR}/vault.service
+  sudo chmod 0664 $${SYSTEMD_DIR}/vault*
+else
+  logger "Service not installed due to OS detection failure"
+  exit 1;
+fi
+
+logger "Vault: enable and start"
+
+sudo systemctl enable vault
+sudo systemctl start vault
+
+sleep 5
+
+logger "Vault: initialize"
+
+vault operator init -key-shares 1 -key-threshold 1 -format=json > /tmp/key.json
+sudo chown ubuntu:ubuntu /tmp/key.json
+
+logger "Vault: Save 'root_token' and 'unseal_key' for 'ubuntu' user"
+
+VAULT_TOKEN=$(cat /tmp/key.json | jq -r ".root_token")
+VAULT_UNSEAL_KEY=$(cat /tmp/key.json | jq -r ".unseal_keys_b64[]")
+
+echo $VAULT_TOKEN > /home/ubuntu/root_token
+sudo chown ubuntu:ubuntu /home/ubuntu/root_token
+echo $VAULT_TOKEN > /home/ubuntu/.vault-token
+sudo chown ubuntu:ubuntu /home/ubuntu/.vault-token
+
+echo $VAULT_UNSEAL_KEY > /home/ubuntu/unseal_keys
+sudo chown ubuntu:ubuntu /home/ubuntu/unseal_keys
+
+logger "Vault: unseal"
+
+vault operator unseal $VAULT_UNSEAL_KEY
+
+logger "ENV: Set VAULT_TOKEN"
+
+export VAULT_TOKEN=$VAULT_TOKEN
+
+logger "OS: wait (10s) for Vault to finish preparations"
+
+sleep 10
+
+logger "RabbitMQ: install and start"
+
+sudo apt-get update
+sudo apt-get -y install rabbitmq-server --fix-missing
+sudo service rabbitmq-server start
+
+sleep 5
+
+logger "RabbitMQ: enable HTTP management port"
+
+sudo rabbitmq-plugins enable rabbitmq_management
+
+logger "RabbitMQ: create user and assign to administrators"
+
+sudo rabbitmqctl add_user learn_vault hashicorp
+sudo rabbitmqctl set_user_tags learn_vault administrator
+
+logger "Filesystem: create a password policy file"
+
+tee /home/ubuntu/common_policy.hcl > /dev/null <<EOF
+length=20
+
+rule "charset" {
+  charset = "abcdefghijklmnopqrstuvwxyz"
+  min-chars = 1
+}
+
+rule "charset" {
+  charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  min-chars = 1
+}
+
+rule "charset" {
+  charset = "0123456789"
+  min-chars = 1
+}
+
+rule "charset" {
+  charset = "!@#$%^&*"
+  min-chars = 1
+}
+EOF
+
+sudo chown ubuntu:ubuntu /home/ubuntu/common_policy.hcl
+
+%{ if tpl_configure_vault_server == "yes" }
+
+logger "Vault: create the password policy"
+
+vault write sys/policies/password/common_policy policy=@/home/ubuntu/common_policy.hcl
+
+logger "Vault: generate a password from the policy"
+
+vault read sys/policies/password/common_policy/generate
+
+logger "Vault: enable and configure RabbitMQ secrets engine WITHOUT password policy"
+
+vault secrets enable -path rabbitmq-no-policy rabbitmq
+
+vault write rabbitmq-no-policy/config/connection \
+    connection_uri=http://localhost:15672 \
+    username="learn_vault" \
+    password="hashicorp"
+
+vault write rabbitmq-no-policy/roles/example vhosts='{"/":{"write": ".*", "read": ".*"}}'
+
+logger "Vault: enable and configure RabbitMQ secrets engine WITH password policy"
+
+vault secrets enable -path=rabbitmq-with-policy rabbitmq
+
+vault write rabbitmq-with-policy/config/connection \
+    connection_uri=http://localhost:15672 \
+    username="learn_vault" \
+    password="hashicorp" \
+    password_policy="common_policy"
+
+vault write rabbitmq-with-policy/roles/example vhosts='{"/":{"write": ".*", "read": ".*"}}'
+
+%{ endif }
+
+logger "Complete"

--- a/secrets/password-policies/aws/templates/userdata-vault-server.tpl
+++ b/secrets/password-policies/aws/templates/userdata-vault-server.tpl
@@ -348,14 +348,14 @@ vault read sys/policies/password/common_policy/generate
 
 logger "Vault: enable and configure RabbitMQ secrets engine WITHOUT password policy"
 
-vault secrets enable -path rabbitmq-no-policy rabbitmq
+vault secrets enable -path rabbitmq-default-policy rabbitmq
 
-vault write rabbitmq-no-policy/config/connection \
+vault write rabbitmq-default-policy/config/connection \
     connection_uri=http://localhost:15672 \
     username="learn_vault" \
     password="hashicorp"
 
-vault write rabbitmq-no-policy/roles/example vhosts='{"/":{"write": ".*", "read": ".*"}}'
+vault write rabbitmq-default-policy/roles/example vhosts='{"/":{"write": ".*", "read": ".*"}}'
 
 logger "Vault: enable and configure RabbitMQ secrets engine WITH password policy"
 

--- a/secrets/password-policies/aws/templates/userdata-vault-server.tpl
+++ b/secrets/password-policies/aws/templates/userdata-vault-server.tpl
@@ -310,7 +310,7 @@ sudo rabbitmqctl set_user_tags learn_vault administrator
 
 logger "Filesystem: create a password policy file"
 
-tee /home/ubuntu/common_policy.hcl > /dev/null <<EOF
+tee /home/ubuntu/example_policy.hcl > /dev/null <<EOF
 length=20
 
 rule "charset" {
@@ -334,17 +334,17 @@ rule "charset" {
 }
 EOF
 
-sudo chown ubuntu:ubuntu /home/ubuntu/common_policy.hcl
+sudo chown ubuntu:ubuntu /home/ubuntu/example_policy.hcl
 
 %{ if tpl_configure_vault_server == "yes" }
 
 logger "Vault: create the password policy"
 
-vault write sys/policies/password/common_policy policy=@/home/ubuntu/common_policy.hcl
+vault write sys/policies/password/example policy=@/home/ubuntu/example_policy.hcl
 
 logger "Vault: generate a password from the policy"
 
-vault read sys/policies/password/common_policy/generate
+vault read sys/policies/password/example/generate
 
 logger "Vault: enable and configure RabbitMQ secrets engine WITHOUT password policy"
 
@@ -365,7 +365,7 @@ vault write rabbitmq-with-policy/config/connection \
     connection_uri=http://localhost:15672 \
     username="learn_vault" \
     password="hashicorp" \
-    password_policy="common_policy"
+    password_policy="example"
 
 vault write rabbitmq-with-policy/roles/example vhosts='{"/":{"write": ".*", "read": ".*"}}'
 

--- a/secrets/password-policies/aws/terraform.tfvars.example
+++ b/secrets/password-policies/aws/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# AWS EC2 Region
+# default: 'us-east-1'
+# @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+aws_region = "us-east-1"
+
+# AWS EC2 Availability Zone
+# default: 'us-east-1a'
+# @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#using-regions-availability-zones-launching
+availability_zones = "us-east-1a"
+
+# AWS EC2 Key Pair
+# @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
+key_name = "learn-vault-key"
+
+# Specify a name here to tag all instances
+# default: 'learn-vault-raft_storage'
+environment_name = "learn-vault"

--- a/secrets/password-policies/aws/variables.tf
+++ b/secrets/password-policies/aws/variables.tf
@@ -1,0 +1,42 @@
+# AWS region and AZs in which to deploy
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "availability_zones" {
+  default = "us-east-1a"
+}
+
+# All resources will be tagged with this
+variable "environment_name" {
+  default = "plugin-password-polices"
+}
+
+variable "vault_server_private_ip" {
+  description = "The private ip of the Vault server"
+  default = "10.0.101.21"
+}
+
+# URL for Vault OSS binary
+variable "vault_binary_url" {
+  default = "https://releases.hashicorp.com/vault/1.4.3/vault_1.4.3_linux_amd64.zip"
+}
+
+# Instance size
+variable "instance_type" {
+  default = "t2.micro"
+}
+
+# SSH key name to access EC2 instances (should already exist) in the AWS Region
+variable "key_name" {
+}
+
+# Instance tags for HashiBot AWS resource reaper
+# variable hashibot_reaper_owner {}
+variable "hashibot_reaper_ttl" {
+  default = 48
+}
+
+variable "configure_vault_server" {
+  default = "yes"
+}

--- a/secrets/password-policies/aws/variables.tf
+++ b/secrets/password-policies/aws/variables.tf
@@ -19,7 +19,7 @@ variable "vault_server_private_ip" {
 
 # URL for Vault OSS binary
 variable "vault_binary_url" {
-  default = "https://releases.hashicorp.com/vault/1.4.3/vault_1.4.3_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.5.0-rc/vault_1.5.0-rc_linux_amd64.zip"
 }
 
 # Instance size

--- a/secrets/password-policies/aws/variables.tf
+++ b/secrets/password-policies/aws/variables.tf
@@ -37,6 +37,10 @@ variable "hashibot_reaper_ttl" {
   default = 48
 }
 
+# The Vault server is configured with the scenario completed.
+# Set this to:
+#   - "yes" for configuration complete
+#   - "no" for configuration required (Have the practitioner do it)
 variable "configure_vault_server" {
-  default = "yes"
+  default = "no"
 }

--- a/secrets/password-policies/aws/version.tf
+++ b/secrets/password-policies/aws/version.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
These assets are provided to perform the tasks described in the "User Configurable Password Generation for Secret Engines" guide that is under review. The scripts currently do all the work of setting up RabbitMQ, the password policy, and two secrets engines for RabbitMQ (one with policy and one without).

## Testing

The current Vault binary does not provide support for this to work.

If you want to try this then you will need to define the following URL in `terraform.tfvars`:

```hcl
vault_binary_url = "https://lynn-vault-binaries.s3.us-east-2.amazonaws.com/vault"
```

This will load the binary that I built for Vault 1.5