### PR TITLE
Disables the SSH OTP from auto-configuring so the practitioner can perform the steps

### DIFF
--- a/secrets/sm-ssh-otp/aws/outputs.tf
+++ b/secrets/sm-ssh-otp/aws/outputs.tf
@@ -9,20 +9,10 @@ output "endpoints" {
   vault-server (${aws_instance.vault-server.public_ip}) | internal: (${aws_instance.vault-server.private_ip})
     - Initialized and unsealed.
     - The root token and recovery key is stored in /tmp/key.json.
-    - SSH secrets engine ENABLED
-    - User authentication enabled
-        * user: learn_vault
-        * password: hashicorp
 
     $ ssh -l ubuntu ${aws_instance.vault-server.public_ip} -i ${var.key_name}.pem
 
-    # Root token:
-    $ ssh -l ubuntu ${aws_instance.vault-server.public_ip} -i ${var.key_name}.pem "cat ~/root_token"
-
   remote-host (${aws_instance.remote-host.public_ip}) | internal: (${aws_instance.remote-host.private_ip})
-    - Vault SSH helper installed
-    - PAM configured
-    - SSHD configured
 
     $ ssh -l ubuntu ${aws_instance.remote-host.public_ip} -i ${var.key_name}.pem
 

--- a/secrets/sm-ssh-otp/aws/variables.tf
+++ b/secrets/sm-ssh-otp/aws/variables.tf
@@ -47,9 +47,9 @@ variable "hashibot_reaper_ttl" {
 }
 
 variable "configure_vault_server" {
-  default = "yes"
+  default = "no"
 }
 
 variable "configure_remote_host" {
-  default = "yes"
+  default = "no"
 }


### PR DESCRIPTION
- Disables config of the remote host
- Disables config of the Vault server