### PR TITLE
Remove unused hashibot_reaper_ttl value from raft_storage

### DIFF
--- a/operations/raft-storage/aws/variables.tf
+++ b/operations/raft-storage/aws/variables.tf
@@ -45,9 +45,3 @@ variable "instance_type" {
 # SSH key name to access EC2 instances (should already exist) in the AWS Region
 variable "key_name" {
 }
-
-# Instance tags for HashiBot AWS resource reaper
-# variable hashibot_reaper_owner {}
-variable "hashibot_reaper_ttl" {
-  default = 48
-}


### PR DESCRIPTION
I couldn't find any more references to the HashiBot reaper, proposing to drop it.