### PR TITLE
Update Vault Spring demo & resolve broken Postgres

### DIFF
--- a/secrets/spring-cloud-vault/scripts/vault.sh
+++ b/secrets/spring-cloud-vault/scripts/vault.sh
@@ -38,7 +38,9 @@ vault secrets enable database
 vault write database/config/postgresql \
   plugin_name=postgresql-database-plugin \
   allowed_roles="*" \
-  connection_url="postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
+  connection_url="postgresql://{{username}}:{{password}}@localhost:5432/postgres?sslmode=disable" \
+  username="postgres" \
+  password="p@sSw0rd_"
 
 #Create the DB order role
 vault write database/roles/order \

--- a/secrets/spring-cloud-vault/vagrant-local/README.md
+++ b/secrets/spring-cloud-vault/vagrant-local/README.md
@@ -27,7 +27,7 @@ dc6a3454b323     vault:0.10.0     "docker-entrypoint..."   7 minutes ago     Up 
 [vagrant@demo ~]$ docker logs vault
 
 # The Spring server takes about 20 seconds to start. Check the Spring logs
-[vagrant@demo ~]$ docker logs spring -f
+[vagrant@demo ~]$ sleep 20s; docker logs spring -f
 ```
 
 ### Test the App

--- a/secrets/spring-cloud-vault/vagrant-local/Vagrantfile
+++ b/secrets/spring-cloud-vault/vagrant-local/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant.configure("2") do |config|
     demo.vm.provision "shell", inline: $vault_install
     demo.vm.provision "docker" do |d|
       d.run "postgres",
-        args: "--net=host -d"
+        args: "--net=host -d -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=p@sSw0rd_ -e PGPASSWORD=p@sSw0rd_"
       d.run "vault",
         image: "vault:latest",
         args: "--net=host --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' -d"


### PR DESCRIPTION
- Postgres containers now require setting admin password, so set
  admin password value to 'p@sSw0rd_' at `docker run` time
- Updated secrets engine connection parameter to use templated
  credentials since Vault was warning about it