### PR TITLE
Fix cluster.sh crash when vault isn't running

### DIFF
--- a/operations/raft-ha-storage/new_cluster/cluster.sh
+++ b/operations/raft-ha-storage/new_cluster/cluster.sh
@@ -284,7 +284,9 @@ function setup_vault_1 {
 
   set -aex
   # Kill all previous server instances
-  ps aux | grep "vault server" | grep -v grep | awk '{print $2}' | xargs kill
+  for pid in $(ps aux | grep "vault server" | grep -v grep | awk '{print $2}'); do
+      kill ${pid}
+  done
 
   local vault_node_name="vault_1"
   local vault_config_file=$demo_home/config-$vault_node_name.hcl


### PR DESCRIPTION
The command './cluster.sh setup vault_1' breaks dumping the output of
'kill -h' when there's no vault server running.

This patch ensures kill will only be called if the PID list for vault
server is not empty.