### PR TITLE
Fix delete operation in mock secrets plugin

### DIFF
--- a/secrets/mock/backend.go
+++ b/secrets/mock/backend.go
@@ -94,7 +94,13 @@ func (b *backend) handleRead(ctx context.Context, req *logical.Request, data *fr
 
 	// Decode the data
 	var rawData map[string]interface{}
-	if err := jsonutil.DecodeJSON(b.store[req.ClientToken+"/"+path], &rawData); err != nil {
+	fetchedData := b.store[req.ClientToken+"/"+path]
+	if fetchedData == nil {
+		resp := logical.ErrorResponse("No value at %v%v", req.MountPoint, path)
+		return resp, nil
+	}
+
+	if err := jsonutil.DecodeJSON(fetchedData, &rawData); err != nil {
 		return nil, errwrap.Wrapf("json decoding failed: {{err}}", err)
 	}
 
@@ -138,7 +144,7 @@ func (b *backend) handleDelete(ctx context.Context, req *logical.Request, data *
 	path := data.Get("path").(string)
 
 	// Remove entry for specified path
-	delete(b.store, path)
+	delete(b.store, req.ClientToken+"/"+path)
 
 	return nil, nil
 }


### PR DESCRIPTION
The delete operation specified the incorrect path to the secret. This
meant that when the delete operation occurred, the target secret was
not cleaned up.
```
adammo@soup:~/Downloads$ vault secrets enable mock
Success! Enabled the mock secrets engine at: mock/
adammo@soup:~/Downloads$ vault write mock/test hello='world'
Success! Data written to: mock/test
adammo@soup:~/Downloads$ vault read mock/test
Key      Value
---      -----
hello    world
adammo@soup:~/Downloads$ vault delete mock/test
Success! Data deleted (if it existed) at: mock/test
adammo@soup:~/Downloads$ vault read mock/test
Key      Value
---      -----
hello    world
```
Now it correctly deletes the secret and doesn't explode when looking up a path that doesn't exist.
```
adammo@soup:~/Downloads$ vault secrets enable mock
Success! Enabled the mock secrets engine at: mock/
adammo@soup:~/Downloads$ vault write mock/test message='hello'
Success! Data written to: mock/test
adammo@soup:~/Downloads$ vault delete mock/test
Success! Data deleted (if it existed) at: mock/test
adammo@soup:~/Downloads$ vault read mock/test
Error reading mock/test: Error making API request.

URL: GET http://127.0.0.1:8200/v1/mock/test
Code: 400. Errors:

* No value at mock/test
```