### PR TITLE
added missing JQ package in setup.pl for azure keyvault auto unseal demo

### DIFF
--- a/operations/azure-keyvault-unseal/setup.tpl
+++ b/operations/azure-keyvault-unseal/setup.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # sudo apt-get install -y unzip jq
-sudo apt update && sudo apt install -y unzip
+sudo apt update && sudo apt install -y unzip jq
 
 VAULT_ZIP="vault.zip"
 VAULT_URL="${vault_download_url}"


### PR DESCRIPTION
seems like jq is no more available by default.
this breaks the generation of the jwt token "embedded" in the `/tmp/azure_auth.sh`

This very tiny PR adds the missing JQ package to fix this.
