### PR TITLE
secrets/mock: update Factory and backend constructor

### DIFF
--- a/secrets/mock/backend.go
+++ b/secrets/mock/backend.go
@@ -12,8 +12,34 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+// backend wraps the backend framework and adds a map for storing key value pairs
+type backend struct {
+	*framework.Backend
+
+	store map[string][]byte
+}
+
+var _ logical.Factory = Factory
+
 // Factory configures and returns Mock backends
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b, err := newBackend()
+	if err != nil {
+		return nil, err
+	}
+
+	if conf == nil {
+		return nil, fmt.Errorf("configuration passed into backend is nil")
+	}
+
+	if err := b.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func newBackend() (*backend, error) {
 	b := &backend{
 		store: make(map[string][]byte),
 	}
@@ -21,24 +47,12 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	b.Backend = &framework.Backend{
 		Help:        strings.TrimSpace(mockHelp),
 		BackendType: logical.TypeLogical,
+		Paths: framework.PathAppend(
+			b.paths(),
+		),
 	}
-
-	b.Backend.Paths = append(b.Backend.Paths, b.paths()...)
-
-	if conf == nil {
-		return nil, fmt.Errorf("configuration passed into backend is nil")
-	}
-
-	b.Backend.Setup(ctx, conf)
 
 	return b, nil
-}
-
-// backend wraps the backend framework and adds a map for storing key value pairs
-type backend struct {
-	*framework.Backend
-
-	store map[string][]byte
 }
 
 func (b *backend) paths() []*framework.Path {


### PR DESCRIPTION
This plugin updates the `Factory` function to call a backend constructor function (`newBackend`) to instantiate a backend object, which aligns more closely to the pattern observed in various other backends.