### PR TITLE
[Vault 1.6] Add a tag to VM

### DIFF
--- a/operations/raft-storage/aws/main.tf
+++ b/operations/raft-storage/aws/main.tf
@@ -76,6 +76,7 @@ resource "aws_instance" "vault-server" {
 
   tags = {
     Name = "${var.environment_name}-vault-server-${var.vault_server_names[count.index]}"
+    cluster_name = "raft-test"
   }
 
   lifecycle {

--- a/operations/raft-storage/aws/variables.tf
+++ b/operations/raft-storage/aws/variables.tf
@@ -34,7 +34,7 @@ variable "vault_server_private_ips" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.5.3/vault_1.5.3_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0-rc/vault_1.6.0-rc_linux_amd64.zip"
 }
 
 # Instance size


### PR DESCRIPTION
This PR: 

- Updates to use Vault 1.6.0 RC binary
- Add additional tag (`cluster_name` = `raft-test`) which can be used to search instances