### PR TITLE
Remove comma from oidc config

### DIFF
--- a/identity/oidc-auth/README.md
+++ b/identity/oidc-auth/README.md
@@ -38,8 +38,8 @@ vault auth enable oidc
 
 vault write auth/oidc/config \
     oidc_discovery_url="https://accounts.google.com" \
-    oidc_client_id="YOUR_GOOGLE_API_CLIENT_ID", \
-    oidc_client_secret="YOUR_GOOGLE_API_CLIENT_SECRET", \
+    oidc_client_id="YOUR_GOOGLE_API_CLIENT_ID" \
+    oidc_client_secret="YOUR_GOOGLE_API_CLIENT_SECRET" \
     default_role="gmail"
 
 ```


### PR DESCRIPTION
The comma is not needed and it invalidates the client ID and secret stored in vault