### PR TITLE
Upgrade Vault version to v1.6.0

### DIFF
--- a/identity/vault-agent-caching/terraform-aws/variables.tf
+++ b/identity/vault-agent-caching/terraform-aws/variables.tf
@@ -24,7 +24,7 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary

--- a/identity/vault-agent-demo/terraform-aws/variables.tf
+++ b/identity/vault-agent-demo/terraform-aws/variables.tf
@@ -24,7 +24,7 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary

--- a/identity/vault-agent-templates/terraform-aws/variables.tf
+++ b/identity/vault-agent-templates/terraform-aws/variables.tf
@@ -24,7 +24,7 @@ variable "vault_server_count" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 # URL for Consul OSS binary

--- a/operations/aws-kms-unseal/terraform-aws/variables.tf
+++ b/operations/aws-kms-unseal/terraform-aws/variables.tf
@@ -7,7 +7,7 @@ variable "aws_zone" {
 }
 
 variable "vault_url" {
-  default = "https://releases.hashicorp.com/vault/1.5.3/vault_1.5.3_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 variable "vpc_cidr" {

--- a/operations/gcp-kms-unseal/variables.tf
+++ b/operations/gcp-kms-unseal/variables.tf
@@ -1,5 +1,5 @@
 variable "vault_url" {
-  default = "https://releases.hashicorp.com/vault/1.5.3/vault_1.5.3_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 variable "gcloud-project" {

--- a/operations/raft-storage/aws/variables.tf
+++ b/operations/raft-storage/aws/variables.tf
@@ -34,7 +34,7 @@ variable "vault_server_private_ips" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.6.0-rc/vault_1.6.0-rc_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 # Instance size

--- a/secrets/password-policies/aws/variables.tf
+++ b/secrets/password-policies/aws/variables.tf
@@ -19,7 +19,7 @@ variable "vault_server_private_ip" {
 
 # URL for Vault OSS binary
 variable "vault_binary_url" {
-  default = "https://releases.hashicorp.com/vault/1.5.0-rc/vault_1.5.0-rc_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 # Instance size

--- a/secrets/sm-ssh-otp/aws/variables.tf
+++ b/secrets/sm-ssh-otp/aws/variables.tf
@@ -24,7 +24,7 @@ variable "remote_host_private_ip" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.4.3/vault_1.4.3_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.6.0/vault_1.6.0_linux_amd64.zip"
 }
 
 variable "vault_ssh_helper_version" {


### PR DESCRIPTION
Upgrade the default Vault version to v1.6.0 on Terraform variable files that are associated with Vault Learn tutorials 