### PR TITLE
Fix typo in README.md

### DIFF
--- a/identity/vault-agent-k8s-demo/README.md
+++ b/identity/vault-agent-k8s-demo/README.md
@@ -59,7 +59,7 @@ To perform the tasks described in this guide, you need:
     $ kubectl get configmap example-vault-agent-config -o yaml
 
     # Finally, create vault-agent-example Pod
-    $ kubectl apply -f example-k8s-spec.yml --record
+    $ kubectl apply -f example-k8s-spec.yaml --record
     ```
 
     This takes a minute or so for the Pod to become fully up and running.


### PR DESCRIPTION
File extension of `example-k8s-spec.yaml` was incorrectly mentioned as `example-k8s-spec.yml` in one of the commands mentioned in README.md