### PR TITLE
Update to .NET 5.0.2 due to CVE

### DIFF
--- a/secrets/dotnet-vault/ProjectApi/ProjectApi.csproj
+++ b/secrets/dotnet-vault/ProjectApi/ProjectApi.csproj
@@ -5,18 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.0" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.0" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.2" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
-    <PackageReference Include="VaultSharp" Version="1.4.0.5" />
+    <PackageReference Include="VaultSharp" Version="1.6.0.2" />
   </ItemGroup>
 
 </Project>

--- a/secrets/dotnet-vault/README.md
+++ b/secrets/dotnet-vault/README.md
@@ -1,6 +1,6 @@
-# HashiCorp Vault with .NET Core Example
+# HashiCorp Vault with .NET Example
 
-These assets are provided to show how to use HashiCorp Vault with .NET Core.
+These assets are provided to show how to use HashiCorp Vault with .NET.
 It uses two patterns:
 
 - Vault C# Library for Static Secrets Injection
@@ -8,8 +8,8 @@ It uses two patterns:
 
 For complete instructions, visit the following links:
 
-- [Using HashiCorp Vault C# Client with .NET Core](https://learn.hashicorp.com/tutorials/vault/dotnet-httpclient)
-- [Using HashiCorp Vault Agent with .NET Core](https://learn.hashicorp.com/tutorials/vault/dotnet-vault-agent)
+- [Using HashiCorp Vault C# Client with .NET](https://learn.hashicorp.com/tutorials/vault/dotnet-httpclient)
+- [Using HashiCorp Vault Agent with .NET](https://learn.hashicorp.com/tutorials/vault/dotnet-vault-agent)
 
 
 ---
@@ -18,7 +18,7 @@ For complete instructions, visit the following links:
 
 - [Docker Compose](https://docs.docker.com/compose/)
 - [Docker](https://docs.docker.com/get-docker/)
-- [.NET Core 5.0+](https://dotnet.microsoft.com/download/dotnet/5.0)
+- [.NET 5.0+](https://dotnet.microsoft.com/download/dotnet/5.0)
 - [VaultSharp](https://github.com/rajanadar/VaultSharp)
 
 ## Demo Script Guide
@@ -53,7 +53,7 @@ The following files are provided as demo scripts:
 
 ### Demo Workflow
 
-> **NOTE:** DON'T FORGET that this demo requires .NET Core and Docker Compose to run the example application!
+> **NOTE:** DON'T FORGET that this demo requires .NET 5.0+ and Docker Compose to run the example application!
 
 1. Run `demo_setup.sh`. This creates a Vault instance (in development mode) and
    a Microsoft SQL Server database with a table prepopulated with data.
@@ -149,7 +149,7 @@ username and password with a lifetime of five minutes.
      Microsoft.Data.SqlClient.SqlException (0x80131904): Login failed for user 'v-approle-projects-api-role-rOrdDahOU9G28eL6tWyD-1605535468'.
    ```
 
-1. To get the application working again, exit out of `run_app.sh` and restart the .NET Core application.
+1. To get the application working again, exit out of `run_app.sh` and restart the .NET application.
    This issues a new set of database credentials.
 
 To handle dynamic database credentials (rotate them every five minutes), you can use Vault Agent

--- a/secrets/dotnet-vault/docker-compose-vault-agent-template.yml
+++ b/secrets/dotnet-vault/docker-compose-vault-agent-template.yml
@@ -2,7 +2,7 @@ version: "3.3"
 services:
 
   vault-agent:
-    image: vault:1.6.0
+    image: vault:1.6.1
     restart: always
     command: [ 'vault', 'agent', '-config=/vault/ProjectApi/vault-agent/config-vault-agent-template.hcl']
     volumes:

--- a/secrets/dotnet-vault/docker-compose-vault-agent-token.yml
+++ b/secrets/dotnet-vault/docker-compose-vault-agent-token.yml
@@ -2,7 +2,7 @@ version: "3.3"
 services:
 
   vault-agent:
-    image: vault:1.6.0
+    image: vault:1.6.1
     restart: always
     command: [ 'vault', 'agent', '-config=/vault/ProjectApi/vault-agent/config-vault-agent-token.hcl']
     volumes:

--- a/secrets/dotnet-vault/docker-compose.yml
+++ b/secrets/dotnet-vault/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 services:
 
   vault:
-    image: vault:1.6.0
+    image: vault:1.6.1
     restart: always
     command: [ 'vault', 'server', '-dev', '-dev-listen-address=0.0.0.0:8200']
     environment:


### PR DESCRIPTION
I updated the libraries related to ASP.NET and .NET to 5.0.2. A [CVE was reported](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.2/5.0.2.md) and while this example tutorial is unaffected, I wanted to make sure it was not going to be flagged during security scanning.