### PR TITLE
add 2 new Sentinel policies

### DIFF
--- a/governance/sentinel/README.md
+++ b/governance/sentinel/README.md
@@ -39,11 +39,13 @@ inline-iam-resources.sentinel | Sentinel policy that restricts inline AWS IAM po
 max-kv-value-size.sentinel | Sentinel policy that restricts the size of keys written to KVv2 secrets | Needs to be converted to base64 prior to being added with the Vault HTTP API
 my-acl-policy.json | ACL policy to be associated to an user | This policy will allow access to the secret path that will be protected by Sentinel
 prevent-kv-v1-engines.sentinel | Sentinel policy that prevents KVv1 secrets engines from being created in any namespace | This should be deployed in the root namespace and needs to be converted to base64 prior to being added with the Vault HTTP API
+restrict-ttls-of-auth-methods.sentinel | Sentinel policy that imposes maximum limit on `max_lease_ttl` set when enabling Vault auth methods | This should be deployed in the root namespace and needs to be converted to base64 prior to being added with the Vault HTTP API
 secret-example.json | Value representing sensitive information to be stored in Vault | Used to test if user can read/write a secret when Sentinel policy is in place
 user-password.json | Contains user password | Used to create a new user with the permissive ACL policy
 user-payload | Information to create an user | This user will test the Sentinel check
 userpass-auth-payload.json | userpass auth method payload | Used to enable userpass authentication method for our tests
 userpass-password-check.sentinel | Sentinel policy that requires strong passwords for the Userpass auth method | Needs to be converted to base64 prior to being added with the Vault HTTP API
+validate-transit-keys-by-customer.sentinel | Sentinel policy that ensures that each customer logged into an app can only access their own Transit key | The app authenticates against Vault with the same credentials regardless of which customer has logged into it
 
 ### Base64
 The Sentinel policy needs to be encoded as a base64 string prior to submitting to Vault with the Vault HTTP API. In this repository the Sentinel policy "cidr-policy.sentinel" and a few others are already encoded, however if you would like to change or use your own you can run the following command:

--- a/governance/sentinel/restrict-ttls-of-auth-methods.sentinel
+++ b/governance/sentinel/restrict-ttls-of-auth-methods.sentinel
@@ -1,0 +1,78 @@
+# Validate that max_lease_ttl of auth methods is below a threshold
+# Note that max_lease_ttl can be given in seconds or with
+# the s, m, or h suffices. One can even use something like
+# 1h30m15s. Sentinel will combine into something like that, but
+# without the hours if less than 3600 seconds and without the minutes
+# if less than 60 seconds.
+
+import "strings"
+
+# Parameter giving maximum number of seconds for max_lease_ttl
+param MAX_TTL default 3600
+
+# Print some information about the request
+# Note that these messages will only be printed when the policy is violated
+print("Namespace path:", namespace.path)
+print("Request path:", request.path)
+print("Request data:", request.data)
+print("Request operation:", request.operation)
+
+validate_max_ttl = func() {
+  # Set validated to true
+  validated = true
+
+  # Process requests to tune paths
+  if strings.has_suffix(request.path, "tune") {
+    # Check if max_lease_ttl in request.data
+    if "max_lease_ttl" in keys(request.data) {
+      max_lease_ttl = request.data.max_lease_ttl
+      # Treat max_lease_ttl as integer giving seconds
+      if max_lease_ttl > MAX_TTL {
+        print("The value of max_lease_ttl", max_lease_ttl,
+              "exceeds the maximum allowed value:", MAX_TTL)
+        validated = false
+      } // end max_lease_ttl check
+    } // end tune path
+  } else {
+    # Process enabling of auth methods
+    if "config" in keys(request.data) and
+       "max_lease_ttl" in keys(request.data.config) {
+      max_lease_ttl = request.data.config.max_lease_ttl
+      # Treat max_lease_ttl as string that will have h and m separators
+      # and compute total seconds
+      split_mlttl_by_hours = strings.split(max_lease_ttl, "h")
+      if length(split_mlttl_by_hours) is 2 {
+        hours = int(split_mlttl_by_hours[0])
+        mins_and_secs = split_mlttl_by_hours[1]
+      } else {
+        hours = 0
+        mins_and_secs = max_lease_ttl
+      }
+      split_mlttl_by_minutes = strings.split(mins_and_secs, "m")
+      if length(split_mlttl_by_minutes) is 2 {
+        minutes = int(split_mlttl_by_minutes[0])
+        seconds = int(strings.split(split_mlttl_by_minutes[1], "s")[0])
+      } else {
+        minutes = 0
+        seconds = int(strings.split(split_mlttl_by_minutes[0], "s")[0])
+      }
+      total_mlttl_seconds = hours*3600 + minutes*60 + seconds
+      if total_mlttl_seconds > MAX_TTL {
+        print("The value of max_lease_ttl", max_lease_ttl, "which is",
+              total_mlttl_seconds, "seconds exceeds the maximum allowed value",
+              MAX_TTL)
+        validated = false
+      } // end max_lease_ttl_seconds check
+    } // end request.data.config.max_lease_ttl
+  } // end enable path
+
+  return validated
+}
+
+# Main rule
+main = rule when (request.path matches "sys/auth/[^/]*" or
+                  request.path matches "sys/auth/[^/]*/tune" or
+                  request.path matches "sys/mounts/auth/[^/]*/tune") and
+								 request.operation in ["create", "update"] {
+  validate_max_ttl()
+}

--- a/governance/sentinel/validate-transit-keys-by-customer.sentinel
+++ b/governance/sentinel/validate-transit-keys-by-customer.sentinel
@@ -1,0 +1,51 @@
+# Policy that requires that customer parameter matches transit key
+# This assumes that an extra non-standard parameter, `customer`
+# is added to the request sent to transit/encrypt or transit/decrypt endpoints.
+
+# This was created for a customer who had an application service which must
+# encrypt data with a unique set of keys per customer.  Using the transit secrets
+# engine, the service would use a single app role per environment (dev/qa/prod)
+# to authenticate with Vault to access the transit secrets engine. For each
+# customer a distinct Transit key would be created so that the resulting path
+# would be transit/keys/<customer>.
+
+# They wanted a Sentinel policy that the single app role could
+# use in all instances of the app regardless of which customer
+# logged in, but they wanted to make sure that the currently logged
+# in customer could only access their assigned transit key.
+
+# Standard strings import
+import "strings"
+
+# Function that validates states
+validate_customer = func() {
+  # Print some information about the request
+  # Note that these messages will only be printed when the policy is violated
+  print("Namespace path:", namespace.path)
+  print("Request path:", request.path)
+  print("Request data:", request.data)
+  # Parse path.  We assume path starts with transit/encrypt or transit/decrypt
+  # by specifying those paths in this EGP Sentinel policy
+  path_segments = strings.split(request.path, "/")
+	if length(path_segments) is 3 {
+     if "customer" in keys(request.data) {
+  	   if request.data.customer is not path_segments[2] {
+         print("incorrect customer", request.data.customer, "for key", request.path)
+         return false
+       } else {
+         return true
+       } // end customer match check
+     } else {
+       print("no customer provided for key", request.path)
+       return false
+     } // end check customer provided
+  } else {
+    return true
+  } // end path inspection
+}
+
+# Main Rule
+customer_validated = validate_customer()
+main = rule {
+  customer_validated
+}


### PR DESCRIPTION
This PR actually adds two new Sentinel policies, despite the name of the branch suggesting only 1.

restrict-ttls-of-auth-methods.sentinel imposes a maximum limit on `max_lease_ttl` set when enabling Vault auth methods.

validate-transit-keys-by-customer.sentinel ensures that each customer logged into an app can only access their own Transit key. The app authenticates against Vault with the same credentials regardless of which customer has logged into it, but it sends an extra parameter, `customer` when using the transit/encrypt and transit/decrypt paths.  Fortuitously, Vault actually excepts and ignores the extra parameter, but Sentinel is able to see it and verify that it matches the Transit secret engines key the customer is trying to use via the app.