### PR TITLE
Add example for using EKS with HCP Vault

### DIFF
--- a/cloud/eks-hcp-vault/postgres.yaml
+++ b/cloud/eks-hcp-vault/postgres.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: postgres
+      app: postgres
+  template:
+    metadata:
+      labels:
+        service: postgres
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: hashicorpdemoapp/product-api-db:v0.0.14
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: products
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: password
+          volumeMounts:
+            - mountPath: "/var/lib/postgresql/data"
+              name: "pgdata"
+      volumes:
+        - name: pgdata
+          emptyDir: {}

--- a/cloud/eks-hcp-vault/product.yaml
+++ b/cloud/eks-hcp-vault/product.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product
+spec:
+  selector:
+    app: product
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: product
+automountServiceAccountToken: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product
+  labels:
+    app: product
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: product
+  template:
+    metadata:
+      labels:
+        app: product
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "product"
+        vault.hashicorp.com/namespace: "admin"
+        vault.hashicorp.com/agent-inject-secret-conf.json: "database/creds/product"
+        vault.hashicorp.com/agent-inject-template-conf.json: |
+          {
+            "bind_address": ":9090",
+            {{ with secret "database/creds/product" -}}
+            "db_connection": "host=postgres port=5432 user={{ .Data.username }} password={{ .Data.password }} dbname=products sslmode=disable"
+            {{- end }}
+          }
+    spec:
+      serviceAccountName: product
+      containers:
+        - name: product
+          image: hashicorpdemoapp/product-api:v0.0.14
+          ports:
+            - containerPort: 9090
+          env:
+            - name: "CONFIG_FILE"
+              value: "/vault/secrets/conf.json"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 30


### PR DESCRIPTION
These examples are Kubernetes manifests to demonstrate dynamic database credentials using HCP Vault and EKS. Related to https://github.com/hashicorp/learn/pull/3206.