### PR TITLE
Update role creation command

### DIFF
--- a/identity/oidc-auth/README.md
+++ b/identity/oidc-auth/README.md
@@ -48,7 +48,7 @@ vault write auth/oidc/config \
 vault write auth/oidc/role/gmail \
     user_claim="sub" \
     bound_audiences=[YOUR_GOOGLE_API_CLIENT_ID] \
-    allowed_redirect_uris=[http://YOUR_VAULT_ADDR//ui/vault/auth/oidc/oidc/callback] \
+    allowed_redirect_uris="http://YOUR_VAULT_ADDR//ui/vault/auth/oidc/oidc/callback" \
     policies=demo \
     ttl=1h
 ```


### PR DESCRIPTION
The command line doesn't work with [], but it does work with simple quotes.  Possibly the vault CLI is not parsing the list correctly.