### PR TITLE
Envs for VAULT_ADDR and VAULT_TOKEN should not be reqd

### DIFF
--- a/operations/provision-vault/kubernetes/minikube/external-vault/pod-devwebapp-with-annotations.yaml
+++ b/operations/provision-vault/kubernetes/minikube/external-vault/pod-devwebapp-with-annotations.yaml
@@ -13,8 +13,3 @@ spec:
   containers:
     - name: app
       image: burtlo/devwebapp-ruby:k8s
-      env:
-      - name: VAULT_ADDR
-        value: "http://external-vault:8200"
-      - name: VAULT_TOKEN
-        value: root


### PR DESCRIPTION
Once the injector is configured with an external vault address and kubernetes and the kubernetes auth backend is correctly configured with the role there should be no need to expose VAULT_ADDR and VAULT_TOKEN as part of the env as well as commit to git (if necessary). It would kill the whole point of the injector.

Also please correct your learn guide where it says

> Display the pod with annotations pod-devwebapp-with-annotations.yaml

Followed by `cat patch-02-inject-secrets.yml`
The filename following the `cat` command is incorrect and should be `pod-devwebapp-with-annotations.yaml`