### PR TITLE
need permissions for kv-v2 ui for katacoda terminal

### DIFF
--- a/operations/codify-mgmt/oss/policies/eaas-client-policy.hcl
+++ b/operations/codify-mgmt/oss/policies/eaas-client-policy.hcl
@@ -3,6 +3,11 @@ path "kv-v2/data/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
 
+# Permits CRUD operation on kv-v2 ui for katacode env.
+path "kv-v2/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
 # Encrypt data with 'payment' key
 path "transit/encrypt/payment" {
   capabilities = ["update"]


### PR DESCRIPTION
Katacoda environment using Vault UI. For using KV-V2 Ui, eass-client-policy.hcl need to set the permission for ui access of KV-V2