### PR TITLE
Ping the chef-client version to 16.17.18

### DIFF
--- a/identity/vault-chef-approle/terraform-aws/chef-node/main.tf
+++ b/identity/vault-chef-approle/terraform-aws/chef-node/main.tf
@@ -57,6 +57,7 @@ resource "aws_instance" "chef-node" {
     recreate_client         = true
     fetch_chef_certificates = true
     ssl_verify_mode         = ":verify_none"
+    version                 = "16.17.18"
   }
 }
 


### PR DESCRIPTION
Pinning the chef-client version is necessary to ensure that knife is present.  It was removed from chef-client 17.x.y and higher.