### PR TITLE
Update terraform and providers in azure-keyvault-unseal 

### DIFF
--- a/operations/azure-keyvault-unseal/main.tf
+++ b/operations/azure-keyvault-unseal/main.tf
@@ -1,11 +1,11 @@
 # see https://github.com/hashicorp/terraform
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.1.7"
   required_providers {
-    template = "~> 2.1.2"
-    random = "~> 2.3.0"
-    azurerm = "~> 2.20.0"
-    azuread = "~> 0.11.0"
+    template = "~> 2.2.0"
+    random = "~> 3.1.2"
+    azurerm = "~> 3.0.2"
+    azuread = "~> 2.19.1"
   }
 }
 
@@ -57,9 +57,9 @@ resource "azurerm_key_vault" "vault" {
     object_id = data.azuread_service_principal.vault.object_id
 
     key_permissions = [
-      "get",
-      "wrapKey",
-      "unwrapKey",
+      "Get",
+      "WrapKey",
+      "UnwrapKey",
     ]
   }
 
@@ -69,11 +69,11 @@ resource "azurerm_key_vault" "vault" {
     object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
-      "get",
-      "list",
-      "create",
-      "delete",
-      "update",
+      "Get",
+      "List",
+      "Create",
+      "Delete",
+      "Update",
     ]
   }
 

--- a/operations/azure-keyvault-unseal/variables.tf
+++ b/operations/azure-keyvault-unseal/variables.tf
@@ -44,7 +44,7 @@ variable "vm_name" {
 
 variable "vault_version" {
   # NB execute `apt-cache madison vault` to known the available versions.
-  default = "1.5.5"
+  default = "1.9.4"
 }
 
 variable "resource_group_name" {


### PR DESCRIPTION
Upgrade to the latest terraform, azure providers and Vault version in the azure-keyvault-unseal guide.

This makes the guide work in the latest terraform:

Terraform v1.1.7
+ provider.azuread v2.19.1
+ provider.azurerm v3.0.2
+ provider.random v3.1.2
+ provider.template v2.2.0

Key Permissions are now case sensitive:
+ "Get",
+ "WrapKey",
+ "UnwrapKey",
+ "Get",
+ "List",
+ "Create",
+ "Delete",
+ "Update",

Vault version changed from 1.5.5 to 1.9.4