### PR TITLE
Updated azurerm and azuread versions

### DIFF
--- a/operations/azure-keyvault-unseal/main.tf
+++ b/operations/azure-keyvault-unseal/main.tf
@@ -4,8 +4,8 @@ terraform {
   required_providers {
     template = "~> 2.2.0"
     random = "~> 3.1.2"
-    azurerm = "~> 3.0.2"
-    azuread = "~> 2.19.1"
+    azurerm = "~> 3.24.0"
+    azuread = "~> 2.29.0"
   }
 }
 


### PR DESCRIPTION
Updated azuread to version 2.29.0
Updated azurerm to version 3.24.0 as version 3.0.2 gave the following error:
```
Error: expected "access_policy.1.object_id" to be a valid UUID, got

   with azurerm_key_vault.vault,
   on main.tf line 69, in resource "azurerm_key_vault" "vault":
   69:     object_id = data.azurerm_client_config.current.object_id
```