### PR TITLE
updating debian version to 10

### DIFF
--- a/operations/gcp-kms-unseal/main.tf
+++ b/operations/gcp-kms-unseal/main.tf
@@ -16,7 +16,7 @@ resource "google_compute_instance" "vault" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-10"
     }
   }
 


### PR DESCRIPTION
The current version fails with:

```
Error: Error resolving image name 'debian-cloud/debian-9': Could not find image or family debian-cloud/debian9
 with google_compute_instance.vault, on main.tf line 12, in resource "google_compute_instance" "vault": 12: resource "google_compute_instance" "vault" 
```

Updating the version to 10 does resolve the issue.
