### PR TITLE
update readme to refer to new version

### DIFF
--- a/cloud/terraform-hcp-vault/README.md
+++ b/cloud/terraform-hcp-vault/README.md
@@ -6,7 +6,7 @@ The repository contains the following directories:
 
 - `hcp-vault-base`: Terraform example configuration to deploy a Vault cluster on HCP.
 - `hcp-vault-vpc`: Terraform example configuration to deploy a Vault cluster on HCP, deploy a VPC on AWS and peer the VPC with the HashiCorp Virtual Network (HVN).
-- `configure-vault`: Terraform example configuration to create nested namespaces, policies, and other resources.
+- `configure-vault`: Terraform example configuration to create nested namespaces, policies, and other resources - newest version found in [hashicorp-education/learn-vault-hcp-codify-mgmt/](https://github.com/hashicorp-education/learn-vault-hcp-codify-mgmt/)
 
 
 For more information on how to deploy Vault on the HashiCorp Cloud Platform refer to the tutorials on [learn.hashicorp.com](https://learn.hashicorp.com/collections/cloud/vault).


### PR DESCRIPTION
This folder is replaced by hashicorp-education/learn-vault-hcp-codify-mgmt/, so once that is published this should be updated.