### PR TITLE
chore: add errcheck for parsing cli flags in plugins

### DIFF
--- a/plugins/vault-plugin-auth-mock/cmd/vault-plugin-auth-mock/main.go
+++ b/plugins/vault-plugin-auth-mock/cmd/vault-plugin-auth-mock/main.go
@@ -12,19 +12,24 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
-	err := plugin.Serve(&plugin.ServeOpts{
+	if err := plugin.Serve(&plugin.ServeOpts{
 		BackendFactoryFunc: mock.Factory,
 		TLSProviderFunc:    tlsProviderFunc,
-	})
-	if err != nil {
-		logger := hclog.New(&hclog.LoggerOptions{})
-
-		logger.Error("plugin shutting down", "error", err)
-		os.Exit(1)
+	}); err != nil {
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	logger := hclog.New(&hclog.LoggerOptions{})
+	logger.Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }

--- a/plugins/vault-plugin-secrets-hashicups/cmd/vault-plugin-secrets-hashicups/main.go
+++ b/plugins/vault-plugin-secrets-hashicups/cmd/vault-plugin-secrets-hashicups/main.go
@@ -12,19 +12,24 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
-	err := plugin.Serve(&plugin.ServeOpts{
+	if err := plugin.Serve(&plugin.ServeOpts{
 		BackendFactoryFunc: hashicups.Factory,
 		TLSProviderFunc:    tlsProviderFunc,
-	})
-	if err != nil {
-		logger := hclog.New(&hclog.LoggerOptions{})
-
-		logger.Error("plugin shutting down", "error", err)
-		os.Exit(1)
+	}); err != nil {
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	logger := hclog.New(&hclog.LoggerOptions{})
+	logger.Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }

--- a/plugins/vault-plugin-secrets-hashicups/solution/cmd/vault-plugin-secrets-hashicups/main.go
+++ b/plugins/vault-plugin-secrets-hashicups/solution/cmd/vault-plugin-secrets-hashicups/main.go
@@ -12,19 +12,24 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
-	err := plugin.Serve(&plugin.ServeOpts{
+	if err := plugin.Serve(&plugin.ServeOpts{
 		BackendFactoryFunc: hashicups.Factory,
 		TLSProviderFunc:    tlsProviderFunc,
-	})
-	if err != nil {
-		logger := hclog.New(&hclog.LoggerOptions{})
-
-		logger.Error("plugin shutting down", "error", err)
-		os.Exit(1)
+	}); err != nil {
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	logger := hclog.New(&hclog.LoggerOptions{})
+	logger.Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }

--- a/plugins/vault-plugin-secrets-mock/cmd/vault-plugin-secrets-mock/main.go
+++ b/plugins/vault-plugin-secrets-mock/cmd/vault-plugin-secrets-mock/main.go
@@ -12,19 +12,24 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
-	err := plugin.Serve(&plugin.ServeOpts{
+	if err := plugin.Serve(&plugin.ServeOpts{
 		BackendFactoryFunc: mock.Factory,
 		TLSProviderFunc:    tlsProviderFunc,
-	})
-	if err != nil {
-		logger := hclog.New(&hclog.LoggerOptions{})
-
-		logger.Error("plugin shutting down", "error", err)
-		os.Exit(1)
+	}); err != nil {
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	logger := hclog.New(&hclog.LoggerOptions{})
+	logger.Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }


### PR DESCRIPTION
Add a missing error check to plugin examples when parsing CLI flags. At the moment a parse error will be hidden from the end-user and the execution continues. With this change execution fails if `flags.Parse()` returns an error.

Same issue applies to many existing plugin implementations, such as:

- https://github.com/hashicorp/vault-auth-plugin-example/pull/32
- https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/202