### PR TITLE
Update AMI to 22.04

### DIFF
--- a/operations/aws-kms-unseal/terraform-aws/instance.tf
+++ b/operations/aws-kms-unseal/terraform-aws/instance.tf
@@ -13,7 +13,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
   }
 
   filter {


### PR DESCRIPTION
Ubuntu 16.04 Images from canonical are not around. Upgrading the images to 22.04