### PR TITLE
update example to handle race condition

### DIFF
--- a/plugins/vault-plugin-secrets-hashicups/backend.go
+++ b/plugins/vault-plugin-secrets-hashicups/backend.go
@@ -82,6 +82,13 @@ func (b *hashiCupsBackend) getClient(ctx context.Context, s logical.Storage) (*h
 	b.lock.Lock()
 	unlockFunc = b.lock.Unlock
 
+	// Check if another goroutine created clients between RUnlock() and Lock() above
+	if b.client != nil {
+		return b.client, nil
+	}
+
+	// create b.client and return
+	
 	return nil, fmt.Errorf("need to return client")
 }
 


### PR DESCRIPTION
The example code does not include a check to see if another goroutine created the client between the b.lock.RUnlock() and b.lock.Lock() calls.  As this is required for all clients to properly handle this race condition, it should be included in the example code.